### PR TITLE
Send Delegated-IPv6-Prefix attribute in Accounting-Start message

### DIFF
--- a/accel-pppd/radius/acct.c
+++ b/accel-pppd/radius/acct.c
@@ -303,8 +303,7 @@ static void rad_acct_start_timeout(struct triton_timer_t *t)
 
 int rad_acct_start(struct radius_pd_t *rpd)
 {
-	struct ap_session *ses = rpd->ses;
-	struct rad_req_t *req = rad_req_alloc(rpd, CODE_ACCOUNTING_REQUEST, ses->username, 0);
+	struct rad_req_t *req = rad_req_alloc(rpd, CODE_ACCOUNTING_REQUEST, rpd->ses->username, 0);
 
 	if (!req)
 		return -1;
@@ -312,14 +311,6 @@ int rad_acct_start(struct radius_pd_t *rpd)
 	if (rad_req_acct_fill(req)) {
 		log_ppp_error("radius:acct: failed to fill accounting attributes\n");
 		goto out_err;
-	}
-
-	if (ses->ipv6_dp) {
-		struct ipv6db_addr_t *a;
-		list_for_each_entry(a, &ses->ipv6_dp->prefix_list, entry) {
-			rad_packet_add_ipv6prefix(req->pack, NULL, "Delegated-IPv6-Prefix", &a->addr, a->prefix_len);
-		}
-		rpd->ipv6_dp_sent = 1;
 	}
 
 	if (conf_acct_delay_time)

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -227,6 +227,13 @@ int rad_req_acct_fill(struct rad_req_t *req)
 			if (rad_packet_add_ipv6prefix(req->pack, NULL, "Framed-IPv6-Prefix", &a->addr, a->prefix_len))
 				return -1;
 		}
+		if (req->rpd->ses->ipv6_dp) {
+			list_for_each_entry(a, &req->rpd->ses->ipv6_dp->prefix_list, entry) {
+			    if (rad_packet_add_ipv6prefix(req->pack, NULL, "Delegated-IPv6-Prefix", &a->addr, a->prefix_len))
+				return -1;
+			}
+			req->rpd->ipv6_dp_sent = 1;
+		}
 	}
 
 	return 0;

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -227,13 +227,13 @@ int rad_req_acct_fill(struct rad_req_t *req)
 			if (rad_packet_add_ipv6prefix(req->pack, NULL, "Framed-IPv6-Prefix", &a->addr, a->prefix_len))
 				return -1;
 		}
-		if (req->rpd->ses->ipv6_dp) {
-			list_for_each_entry(a, &req->rpd->ses->ipv6_dp->prefix_list, entry) {
-			    if (rad_packet_add_ipv6prefix(req->pack, NULL, "Delegated-IPv6-Prefix", &a->addr, a->prefix_len))
-				return -1;
-			}
-			req->rpd->ipv6_dp_sent = 1;
+	}
+	if (req->rpd->ses->ipv6_dp) {
+		list_for_each_entry(a, &req->rpd->ses->ipv6_dp->prefix_list, entry) {
+		    if (rad_packet_add_ipv6prefix(req->pack, NULL, "Delegated-IPv6-Prefix", &a->addr, a->prefix_len))
+			return -1;
 		}
+		req->rpd->ipv6_dp_sent = 1;
 	}
 
 	return 0;


### PR DESCRIPTION
if Delegated-IPv6-Prefix was received in Access-Accept message, it is necessary to send it in radacct Start message