### PR TITLE
Vadym Yashchenko

### DIFF
--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -1085,27 +1085,39 @@ void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_l
        data->size = count;
 }
 
-void check_username_domain_pass (char * username, char ret [], int ar_size)
+void check_username_domain_pass (char * username, char ret [], int arr_size)
 {
-	strncpy(ret, username, ar_size);
-	if (conf_domain_filter.data)
-	{
-    		for (int i = 0; i < conf_domain_filter.size; ++i)
-    		{
-			char * check = *(conf_domain_filter.data + i);
-			char * pch = strstr(username, check);
-			if (pch)
-			{
-			    int dif = strlen(username) - (pch  - username  + strlen(check));
-			    if (dif)
-			    {
-				break;
-			    }
-			    ret[pch - username] = 0;
-			    break;
-			}
-    		}
-	}
+    strncpy(ret, username, arr_size);
+    bool pass = false;
+    for (int i = 0; i < conf_domain_filter.size; ++i)
+    {
+        char * check = *(conf_domain_filter.data + i);
+        char * pch = strstr(username, check);
+        if (pch)
+        {
+            int dif = strlen(username) - (pch  - username  + strlen(check));
+            if (dif)
+            {
+                break;
+            }
+            ret[pch - username] = 0;
+            char * pos_dog = strchr(ret, '@');
+            if (pos_dog && (pos_dog == strlen(ret) + ret - 1))
+            {
+                ret[strlen(ret) - 1] = 0;
+            }
+            pass = true;
+            break;
+        }
+    }
+    if (!pass)
+    {
+        char * pos_dog = strchr(ret, '@');
+        if (pos_dog && (pos_dog == strlen(ret) + ret - 1))
+        {
+            ret[strlen(ret) - 1] = 0;
+        }
+    }
 }
 
 DEFINE_INIT(51, radius_init);

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -414,7 +414,7 @@ static int rad_pwdb_check(struct pwdb_t *pwdb, struct ap_session *ses, pwdb_call
 	char username1[256];
 
         char short_name[256];
-        check_username_domain_pass(username, short_name);
+        check_username_domain_pass(username, short_name, sizeof(short_name));
 
 	if (conf_default_realm && !strchr(short_name, '@')) {
 		int len = strlen(short_name);
@@ -727,7 +727,7 @@ static void ses_finished(struct ap_session *ses)
 		fr = next;
 	}
 
-	_free(conf_domain_filter.data);
+	//_free(conf_domain_filter.data);
 
 	list_del(&rpd->pd.entry);
 
@@ -1058,34 +1058,47 @@ void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_l
 		if (!count)
 		{
 				data->data = (char **)_malloc(sizeof(char *) * (++count));
-				*data->data = opt->val;
+				if (data->data)
+				{
+					*data->data = opt->val;
+					break;
+				}
 		}
 		else
 		{
 				data->data = (char **)_realloc(data->data, sizeof(char *) * (++count));
-				*(data->data + count - 1) = opt->val;
+				if (data->data)
+				{
+					*(data->data + count - 1) = opt->val;
+					break;
+				}
+
+				
 		}
 	}
        data->size = count;
 }
 
-void check_username_domain_pass (char * username, char ret [])
+void check_username_domain_pass (char * username, char ret [], int ar_size)
 {
-    strcpy(ret, username);
+    strncpy(ret, username, ar_size);
     for (int i = 0; i < conf_domain_filter.size; ++i)
     {
-        char * check = *(conf_domain_filter.data + i);
-        char * pch = strstr(username, check);
-        if (pch)
-        {
-            int dif = strlen(username) - (pch  - username  + strlen(check));
-            if (dif)
-            {
-                break;
-            }
-            ret[pch - username] = 0;
-            break;
-        }
+	if (conf_domain_filter.data + i)
+	{
+		char * check = *(conf_domain_filter.data + i);
+		char * pch = strstr(username, check);
+		if (pch)
+		{
+		    int dif = strlen(username) - (pch  - username  + strlen(check));
+		    if (dif)
+		    {
+		        break;
+		    }
+		    ret[pch - username] = 0;
+		    break;
+		}
+	}
     }
 }
 

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -1061,6 +1061,9 @@ void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_l
 				if (data->data)
 				{
 					*data->data = opt->val;
+				}
+				else
+				{
 					break;
 				}
 		}
@@ -1070,6 +1073,9 @@ void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_l
 				if (data->data)
 				{
 					*(data->data + count - 1) = opt->val;
+				}
+				else
+				{
 					break;
 				}
 
@@ -1081,25 +1087,25 @@ void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_l
 
 void check_username_domain_pass (char * username, char ret [], int ar_size)
 {
-    strncpy(ret, username, ar_size);
-    for (int i = 0; i < conf_domain_filter.size; ++i)
-    {
-	if (conf_domain_filter.data + i)
+	strncpy(ret, username, ar_size);
+	if (conf_domain_filter.data)
 	{
-		char * check = *(conf_domain_filter.data + i);
-		char * pch = strstr(username, check);
-		if (pch)
-		{
-		    int dif = strlen(username) - (pch  - username  + strlen(check));
-		    if (dif)
-		    {
-		        break;
-		    }
-		    ret[pch - username] = 0;
-		    break;
-		}
+    		for (int i = 0; i < conf_domain_filter.size; ++i)
+    		{
+			char * check = *(conf_domain_filter.data + i);
+			char * pch = strstr(username, check);
+			if (pch)
+			{
+			    int dif = strlen(username) - (pch  - username  + strlen(check));
+			    if (dif)
+			    {
+				break;
+			    }
+			    ret[pch - username] = 0;
+			    break;
+			}
+    		}
 	}
-    }
 }
 
 DEFINE_INIT(51, radius_init);

--- a/accel-pppd/radius/radius.h
+++ b/accel-pppd/radius/radius.h
@@ -145,6 +145,6 @@ int rad_packet_add_ifid(struct rad_packet_t *pack, const char *vendor, const cha
 int rad_packet_add_ipv6prefix(struct rad_packet_t *pack, const char *vendor, const char *name, struct in6_addr *prefix, int len);
 
 void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_lines * data);
-void check_username_domain_pass (char * username, char ret []);
+void check_username_domain_pass (char * username, char ret [], int ar_size);
 #endif
 

--- a/accel-pppd/radius/radius.h
+++ b/accel-pppd/radius/radius.h
@@ -116,6 +116,12 @@ struct rad_plugin_t
 	int (*send_accounting_request)(struct rad_plugin_t *, struct rad_packet_t *pack);
 };
 
+struct multi_lines
+{
+    char ** data;
+    int size;
+};
+
 void rad_register_plugin(struct ap_session *, struct rad_plugin_t *);
 
 struct rad_dict_attr_t *rad_dict_find_attr(const char *name);
@@ -138,5 +144,7 @@ int rad_packet_add_ipaddr(struct rad_packet_t *pack, const char *vendor, const c
 int rad_packet_add_ifid(struct rad_packet_t *pack, const char *vendor, const char *name, uint64_t ifid);
 int rad_packet_add_ipv6prefix(struct rad_packet_t *pack, const char *vendor, const char *name, struct in6_addr *prefix, int len);
 
+void load_multiline(struct conf_sect_t *sect, char * seek_string, struct multi_lines * data);
+void check_username_domain_pass (char * username, char ret []);
 #endif
 


### PR DESCRIPTION
Added stripe-domain feature into "radius" module

This feature need in the radius module. The patterns for strip of user name have beeing read from accel-ppp.conf. This used to  strip domain name from user name in the procedure of checking user name.