### PR TITLE
Added VRF support

### DIFF
--- a/accel-pppd/cli/show_sessions.c
+++ b/accel-pppd/cli/show_sessions.c
@@ -389,6 +389,14 @@ static void print_ifname(struct ap_session *ses, char *buf)
 	snprintf(buf, CELL_SIZE, "%s", ses->ifname);
 }
 
+static void print_vrf(struct ap_session *ses, char *buf)
+{
+	if (ses->vrf_name)
+		snprintf(buf, CELL_SIZE, "%s", ses->vrf_name);
+	else
+		*buf = 0;
+}
+
 static void print_username(struct ap_session *ses, char *buf)
 {
 	if (ses->username)
@@ -639,6 +647,7 @@ static void init(void)
 	cli_register_simple_cmd2(show_ses_exec, show_ses_help, 2, "show", "sessions");
 
 	cli_show_ses_register("netns", "network namespace name", print_netns);
+	cli_show_ses_register("vrf", "vrf name", print_vrf);
 	cli_show_ses_register("ifname", "interface name", print_ifname);
 	cli_show_ses_register("username", "user name", print_username);
 	cli_show_ses_register("ip", "IP address", print_ip);

--- a/accel-pppd/include/ap_net.h
+++ b/accel-pppd/include/ap_net.h
@@ -32,6 +32,8 @@ struct ap_net {
 	int (*rtnl_open)(struct rtnl_handle *h, int proto);
 	int (*move_link)(struct ap_net *net, int ifindex);
 	int (*get_ifindex)(const char * ifname);
+	int (*set_vrf)(int ifindex, int vrf_ifindex);
+	int (*remove_vrf)(int ifindex);
 	void (*release)(struct ap_net *net);
 };
 

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -73,6 +73,7 @@ struct ap_session
 	char *chan_name;
 	char ifname[AP_IFNAME_LEN];
 	char *ifname_rename;
+	char *vrf_name;
 	int unit_idx;
 	int ifindex;
 	char sessionid[AP_SESSIONID_LEN+1];
@@ -151,6 +152,8 @@ int ap_check_username(const char *username);
 void ap_session_ifup(struct ap_session *ses);
 void ap_session_ifdown(struct ap_session *ses);
 int ap_session_rename(struct ap_session *ses, const char *ifname, int len);
+int ap_session_set_vrf(struct ap_session *ses);
+int ap_session_remove_vrf(struct ap_session *ses);
 
 int ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stats *stats);
 

--- a/accel-pppd/radius/attr_defs.h
+++ b/accel-pppd/radius/attr_defs.h
@@ -297,4 +297,5 @@
 #define Route_IPv6_Information 170
 #define Delegated_IPv6_Prefix_Pool 171
 #define Stateful_IPv6_Address_Pool 172
-#define NAS_Filter_Rule 92
+#define Vendor_Accel_PPP 55999
+#define Accel_VRF_Name 1

--- a/accel-pppd/radius/attr_defs.h
+++ b/accel-pppd/radius/attr_defs.h
@@ -297,3 +297,4 @@
 #define Route_IPv6_Information 170
 #define Delegated_IPv6_Prefix_Pool 171
 #define Stateful_IPv6_Address_Pool 172
+#define NAS_Filter_Rule 92

--- a/accel-pppd/radius/dict/dictionary
+++ b/accel-pppd/radius/dict/dictionary
@@ -73,6 +73,7 @@ $INCLUDE dictionary.rfc4072
 $INCLUDE dictionary.rfc4372
 $INCLUDE dictionary.rfc4679
 $INCLUDE dictionary.rfc4818
+$INCLUDE dictionary.rfc4849
 $INCLUDE dictionary.rfc5176
 $INCLUDE dictionary.rfc6911
 

--- a/accel-pppd/radius/dict/dictionary
+++ b/accel-pppd/radius/dict/dictionary
@@ -73,7 +73,6 @@ $INCLUDE dictionary.rfc4072
 $INCLUDE dictionary.rfc4372
 $INCLUDE dictionary.rfc4679
 $INCLUDE dictionary.rfc4818
-$INCLUDE dictionary.rfc4849
 $INCLUDE dictionary.rfc5176
 $INCLUDE dictionary.rfc6911
 
@@ -81,3 +80,4 @@ $INCLUDE dictionary.microsoft
 $INCLUDE dictionary.cisco
 $INCLUDE dictionary.alcatel
 $INCLUDE dictionary.dhcp
+$INCLUDE dictionary.accel

--- a/accel-pppd/radius/dict/dictionary.accel
+++ b/accel-pppd/radius/dict/dictionary.accel
@@ -1,0 +1,7 @@
+VENDOR          Accel-PPP               55999
+
+BEGIN-VENDOR    Accel-PPP
+
+ATTRIBUTE Accel-VRF-Name                  1      string
+
+END-VENDOR	Accel-PPP

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -240,6 +240,11 @@ void __export ap_session_finished(struct ap_session *ses)
 		ses->ifname_rename = NULL;
 	}
 
+	if (ses->vrf_name) {
+		_free(ses->vrf_name);
+		ses->vrf_name = NULL;
+	}
+
 	if (ses->net)
 		ses->net->release(ses->net);
 


### PR DESCRIPTION
Use Accel-VRF-Name attribute in Access-Accept and CoA messages to set VRF for user interface.
Accel-VRF-Name="/" is used to remove VRF from user interface (return to global routing table)

All VRFs should be manually created in advance, e.g.:
 ip link add VRF_NAME type vrf table RT_TABLE_ID
 ip link set dev VRF_NAME up

(Please read https://www.kernel.org/doc/Documentation/networking/vrf.txt )

CoA-message example to assign VRF for user session:
 echo 'User-Name=bob, Accel-VRF-Name="test"' | radclient -x 127.0.0.1:3799 coa testing123

CoA-message example to remove VRF from user session:
 echo 'User-Name=bob, Accel-VRF-Name="/"' | radclient -x 127.0.0.1:3799 coa testing123

If Accel-VRF-Name is used in Access-Accept message, but VRF is not created or VRF feature is
not supported by Linux kernel, then the session could not be established.
If Accel-VRF-Name is used in CoA message, but VRF is not created or VRF feature is not
supported by Linux kernel, then CoA-NAK will be sent.