### PR TITLE
cli: T40: Show version of running accel-pppd from cli or telnet

### DIFF
--- a/accel-pppd/cli/std_cmd.c
+++ b/accel-pppd/cli/std_cmd.c
@@ -84,6 +84,17 @@ static void show_stat_help(char * const *fields, int fields_cnt, void *client)
 }
 //=============================
 
+static int show_version_exec(const char *cmd, char * const *fields, int fields_cnt, void *client)
+{
+	cli_sendv(client, "%s\r\n", ACCEL_PPP_VERSION);
+}
+
+static void show_version_help(char * const *fields, int fields_cnt, void *client)
+{
+	cli_send(client, "show version - shows version of running accel-pppd\r\n");
+}
+//=============================
+
 static int exit_exec(const char *cmd, char * const *fields, int fields_cnt, void *client)
 {
 	return CLI_CMD_EXIT;
@@ -381,6 +392,7 @@ static void restart_help(char * const *fields, int fields_cnt, void *client)
 static void init(void)
 {
 	cli_register_simple_cmd2(show_stat_exec, show_stat_help, 2, "show", "stat");
+	cli_register_simple_cmd2(show_version_exec, show_version_help, 2, "show", "version");
 	cli_register_simple_cmd2(terminate_exec, terminate_help, 1, "terminate");
 	cli_register_simple_cmd2(reload_exec, reload_help, 1, "reload");
 	cli_register_simple_cmd2(restart_exec, restart_help, 1, "restart");


### PR DESCRIPTION
The addition of this feature will allow you to remotely recognize the version of the accel-pppd via cli or telnet, it will also be possible to monitor the version with monitoring systems such as Zabbix

Task in phabricator
[https://phabricator.accel-ppp.org/T40](https://phabricator.accel-ppp.org/T40)

```
> accel-cmd help
show stat - shows various statistics information
show version - shows version of running accel-pppd
......
> accel-cmd show version
1.12.0-126-g3b74e10
```