### PR TITLE
fix parsing of qdiscs

### DIFF
--- a/accel-pppd/shaper/leaf_qdisc.c
+++ b/accel-pppd/shaper/leaf_qdisc.c
@@ -113,7 +113,7 @@ static int parse_sfq(char *str)
 	for (key = strtok_r(str, " ", &ptr); key; key = strtok_r(NULL, " ", &ptr)) {
 		value = strtok_r(NULL, " ", &ptr);
 		if (!value)
-			return -1;
+			goto out;
 
 		if (strcmp(key, "quantum") == 0) {
 			if (parse_size(value, &conf_lq_arg1))
@@ -147,14 +147,14 @@ static int parse_fq_codel(char *str)
 		if (strcmp(key, "ecn") == 0) {
 			conf_lq_arg6 = 1;
 			continue;
-		} else if (strcmp(str, "noecn") == 0) {
+		} else if (strcmp(key, "noecn") == 0) {
 			conf_lq_arg6 = 0;
 			continue;
 		}
 
 		value = strtok_r(str, " ", &ptr);
 		if (!value)
-			return -1;
+			goto out;
 
 		if (strcmp(key, "limit") == 0) {
 			if (parse_u32(value, &conf_lq_arg1))
@@ -193,13 +193,12 @@ void leaf_qdisc_parse(const char *opt)
 
 	qdisc = strtok_r(str, " ", &ptr);
 	if (qdisc) {
-		params = strtok_r(NULL, " ", &ptr);
 		if (strcmp(qdisc, "sfq") == 0) {
-			if (parse_sfq(params))
+			if (parse_sfq(ptr))
 				goto out_err;
 #ifdef TCA_FQ_CODEL_MAX
 		} else if (strcmp(qdisc, "fq_codel") == 0) {
-			if (parse_fq_codel(params))
+			if (parse_fq_codel(ptr))
 				goto out_err;
 #endif
 		} else

--- a/accel-pppd/shaper/leaf_qdisc.c
+++ b/accel-pppd/shaper/leaf_qdisc.c
@@ -152,7 +152,7 @@ static int parse_fq_codel(char *str)
 			continue;
 		}
 
-		value = strtok_r(str, " ", &ptr);
+		value = strtok_r(NULL, " ", &ptr);
 		if (!value)
 			goto out;
 
@@ -183,7 +183,7 @@ out:
 
 void leaf_qdisc_parse(const char *opt)
 {
-	char *str, *qdisc, *params, *ptr;
+	char *str, *qdisc, *ptr;
 
 	str = strdup(opt);
 	if (!str) {


### PR DESCRIPTION
In the new parsing code there are a few bugs causing parsing to fail, e.g:

log_emerg:
shaper: failed to parse 'fq_codel limit 1024 flows 1024 quantum 1514 target 5ms interval 100ms noecn'
shaper: failed to parse 'fq_codel limit 1024 flows 1024 quantum 1514 target 5ms interval 100ms'

One being an unecessary line to obtain params. `params = strtok_r(NULL, " ", &ptr);`. The actual parameters are held in the `ptr` variable when the qdisc type is read two lines before. 

Later there's a wrong variable used for comparing a string of `noecn`.

I have also changed the return value when `value = strtok_r(NULL, " ", &ptr);` is `NULL`. 
When there is an even number of arguments, the for loop reading the key/value tokens will terminate by itself and this condition will not be reached, but when there's an odd number of arguments (e.g. ecn/noecn) keyword as the last argument then it will be hit and terminate gracefully without printing that parsing has failed.