### PR TITLE
T50: use server mac in arp replies for proxy_arp=2

### DIFF
--- a/accel-pppd/ctrl/ipoe/arp.c
+++ b/accel-pppd/ctrl/ipoe/arp.c
@@ -109,13 +109,8 @@ static void arp_ctx_read(struct _arphdr *ah)
 			pthread_mutex_unlock(&ipoe->lock);
 			goto out;
 		}
-
-		if (ipoe->opt_arp == 2)
-			memcpy(ah2.ar_sha, ses2->hwaddr, ETH_ALEN);
-		else
-			memcpy(ah2.ar_sha, ipoe->hwaddr, ETH_ALEN);
-	} else
-		memcpy(ah2.ar_sha, ipoe->hwaddr, ETH_ALEN);
+	}
+	memcpy(ah2.ar_sha, ipoe->hwaddr, ETH_ALEN);
 
 	pthread_mutex_unlock(&ipoe->lock);
 


### PR DESCRIPTION
proxy_arp=2 should be used for ipoe setup with shared vlan and intra-vlan l2 isolation. accel-ppp should use server mac when sending arp reply message. There is no reason to send subscriber's mac if proxy_arp is enabled

In case of ipoe shared vlan without l2-isolation, proxy_arp=1 should be used