### PR TITLE
vrf: T10: Add VRF support

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -64,6 +64,14 @@ CHECK_INCLUDE_FILE("linux/netfilter/ipset/ip_set.h" HAVE_IPSET)
 INCLUDE(CheckFunctionExists)
 CHECK_FUNCTION_EXISTS(setns HAVE_SETNS)
 
+INCLUDE (CheckCSourceCompiles)
+CHECK_C_SOURCE_COMPILES("
+#include <linux/if_link.h>
+int main(void)
+{
+	return IFLA_VRF_UNSPEC+IFLA_VRF_TABLE;
+}" HAVE_VRF)
+
 ADD_EXECUTABLE(accel-pppd
 	memdebug.c
 	session.c

--- a/accel-pppd/cli/show_sessions.c
+++ b/accel-pppd/cli/show_sessions.c
@@ -384,6 +384,14 @@ static void print_netns(struct ap_session *ses, char *buf)
 	snprintf(buf, CELL_SIZE, "%s", ses->net->name);
 }
 
+static void print_vrf(struct ap_session *ses, char *buf)
+{
+	if (ses->vrf_name)
+		snprintf(buf, CELL_SIZE, "%s", ses->vrf_name);
+	else
+		*buf = 0;
+}
+
 static void print_ifname(struct ap_session *ses, char *buf)
 {
 	snprintf(buf, CELL_SIZE, "%s", ses->ifname);
@@ -639,6 +647,7 @@ static void init(void)
 	cli_register_simple_cmd2(show_ses_exec, show_ses_help, 2, "show", "sessions");
 
 	cli_show_ses_register("netns", "network namespace name", print_netns);
+	cli_show_ses_register("vrf", "vrf name", print_vrf);
 	cli_show_ses_register("ifname", "interface name", print_ifname);
 	cli_show_ses_register("username", "user name", print_username);
 	cli_show_ses_register("ip", "IP address", print_ip);

--- a/accel-pppd/include/ap_net.h
+++ b/accel-pppd/include/ap_net.h
@@ -6,6 +6,7 @@
 
 #include "libnetlink.h"
 #include "list.h"
+#include "config.h"
 
 struct ap_net {
 	struct list_head entry;
@@ -33,6 +34,10 @@ struct ap_net {
 	int (*move_link)(struct ap_net *net, int ifindex);
 	int (*get_ifindex)(const char * ifname);
 	void (*release)(struct ap_net *net);
+#ifdef HAVE_VRF
+	int (*set_vrf)(int ifindex, int vrf_ifindex);
+#endif
+
 };
 
 extern __thread struct ap_net *net;

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -73,6 +73,7 @@ struct ap_session
 	char *chan_name;
 	char ifname[AP_IFNAME_LEN];
 	char *ifname_rename;
+	char *vrf_name;
 	int unit_idx;
 	int ifindex;
 	char sessionid[AP_SESSIONID_LEN+1];
@@ -151,6 +152,9 @@ int ap_check_username(const char *username);
 void ap_session_ifup(struct ap_session *ses);
 void ap_session_ifdown(struct ap_session *ses);
 int ap_session_rename(struct ap_session *ses, const char *ifname, int len);
+#ifdef HAVE_VRF
+int ap_session_vrf(struct ap_session *ses, const char *vrf_name, int len);
+#endif
 
 int ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stats *stats);
 

--- a/accel-pppd/radius/attr_defs.h
+++ b/accel-pppd/radius/attr_defs.h
@@ -1,6 +1,8 @@
 #define VENDOR_Microsoft 311
 #define VENDOR_Accel_PPP 55999
 
+#define Accel_VRF_Name 1
+
 #define User_Name 1
 #define User_Password 2
 #define CHAP_Password 3

--- a/accel-pppd/radius/dict/dictionary
+++ b/accel-pppd/radius/dict/dictionary
@@ -76,6 +76,7 @@ $INCLUDE dictionary.rfc4818
 $INCLUDE dictionary.rfc5176
 $INCLUDE dictionary.rfc6911
 
+$INCLUDE dictionary.accel
 $INCLUDE dictionary.microsoft
 $INCLUDE dictionary.cisco
 $INCLUDE dictionary.alcatel

--- a/accel-pppd/radius/dict/dictionary.accel
+++ b/accel-pppd/radius/dict/dictionary.accel
@@ -1,0 +1,7 @@
+VENDOR			Accel-PPP				55999
+
+BEGIN-VENDOR	Accel-PPP
+
+ATTRIBUTE	Accel-VRF-Name			1		string
+
+END-VENDOR		Accel-PPP

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -24,6 +24,7 @@
 #include "iputils.h"
 #include "spinlock.h"
 #include "mempool.h"
+#include "config.h"
 #include "memdebug.h"
 
 #define SID_SOURCE_SEQ 0
@@ -239,6 +240,11 @@ void __export ap_session_finished(struct ap_session *ses)
 		_free(ses->ifname_rename);
 		ses->ifname_rename = NULL;
 	}
+
+#ifdef HAVE_VRF
+	if (ses->vrf_name)
+		ap_session_vrf(ses, NULL, 0);
+#endif
 
 	if (ses->net)
 		ses->net->release(ses->net);

--- a/config.h.in
+++ b/config.h.in
@@ -2,3 +2,4 @@
 //#cmakedefine RADIUS
 #cmakedefine HAVE_IPSET
 #cmakedefine HAVE_SETNS
+#cmakedefine HAVE_VRF


### PR DESCRIPTION
Added Accel-VRF-Name attribute vendor Accel-PPPP
Add possibility to send Access-Accept and CoA messages to set VRF for the user interface.
(Accel-VRF-Name="0") "0" value is used to return the user interface back to default (global routing table)

All VRFs should be manually created in advance, e.g.:
```
ip link add VRF_NAME type vrf table RT_TABLE_ID
ip link set dev VRF_NAME up
```
(Please read https://www.kernel.org/doc/Documentation/networking/vrf.txt )

CoA-message example to assign VRF for user session:
`echo 'User-Name=bob, Accel-VRF-Name="test"' | radclient -x 127.0.0.1:3799 coa testing123`

CoA-message example to remove VRF from user session:
`echo 'User-Name=bob, Accel-VRF-Name="0"' | radclient -x 127.0.0.1:3799 coa testing123`

If Accel-VRF-Name is used in Access-Accept message, but VRF is not created then the session could not be established.
If Accel-VRF-Name is used in CoA message, but VRF is not created then CoA-NAK will be sent.

Co-authored-by: Sergey V. Lobanov <svlobanov@users.noreply.github.com>
Co-authored-by: Vladislav Grishenko <themiron@users.noreply.github.com>