### PR TITLE
T55: add netlink buffer size configuration parameters

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -43,6 +43,8 @@ thread-count=4
 #max-sessions=1000
 #max-starting=0
 #check-ip=0
+#nl-snd-buffer=32768
+#nl-rcv-buffer=1048576
 
 [ppp]
 verbose=1

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -131,6 +131,12 @@ Specifies maximum concurrent session attempts which server may processed (defaul
 .TP
 .BI "check-ip=" 0|1
 Specifies whether accel-ppp should check if IP already assigned to other client interface (default 0).
+.TP
+.BI "nl-snd-buffer=" n
+Specifies netlink maximum send buffer size (SO_SNDBUF option) (default 32768).
+.TP
+.BI "nl-rcv-buffer=" n
+Specifies netlink maximum receive buffer size (SO_RCVBUF option) (default 1048576).
 .SH [ppp]
 .br
 PPP module configuration.

--- a/accel-pppd/net.c
+++ b/accel-pppd/net.c
@@ -45,6 +45,9 @@ __export __thread struct ap_net *net;
 __export struct ap_net *def_net;
 static int def_ns_fd;
 
+__export int conf_nl_rcvbuf = 1024 * 1024;
+__export int conf_nl_sndbuf = -1;
+
 static int def_socket(int domain, int type, int proto)
 {
 	return socket(domain, type, proto);
@@ -431,6 +434,14 @@ __export struct ap_net *ap_net_open_ns(const char *name)
 static void __init init()
 {
 	const char *opt;
+
+	opt = conf_get_opt("common", "nl-rcv-buffer");
+	if (opt)
+		conf_nl_rcvbuf = atoi(opt);
+
+	opt = conf_get_opt("common", "nl-snd-buffer");
+	if (opt)
+		conf_nl_sndbuf = atoi(opt);
 
 	opt = conf_get_opt("common", "netns-run-dir");
 	if (opt)


### PR DESCRIPTION
Netlink buffers may overflow so it might be useful to increase send and receive 
netlink buffer sizes.
Two parameters to [common] configuration section added: nl-rcv-buffer,
nl-snd-buffer.

It is required to set (sysctl) net.core.wmem_max>=nl-snd-buffer and 
net.core.rmem_max>=nl-rcv-buffer before running accel-pppd

To check current netlink buffer size and related info use the following command:

% ss -f netlink -m 
0 0 rtnl:kernel * skmem:(r0,rb212992,t0,tb212992,f0,w0,o0,bl0,d0)
0 0 rtnl:-1140221812 * skmem:(r0,rb2048000,t0,tb80000,f0,w0,o0,bl0,d0)
0 0 rtnl:accel-pppd/14285 * skmem:(r0,rb2048000,t0,tb65536,f0,w0,o0,bl0,d0)
...

(Please check man ss to get the meaning for r,rb,t,tb,f,w,o,bl and d params)

In the ss output you will see the values doubled from configured.

First accel-pppd netlink socket will use default values (rcv=1048576, snd=32768) 
regardless of configured nl-rcv-buffer and nl-snd-buffer values.