### PR TITLE
Added support for binding device name for radius request and DM/CoA server. 

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -824,8 +824,11 @@ Specifies IP address, port and secret of authentication RADIUS server. (obsolete
 .BI "acct-server=" x.x.x.x:port,secret
 Specifies IP address, port and secret of accounting RADIUS server. (obsolete)
 .TP
-.BI "server=" address,secret[,auth-port=1812][,acct-port=1813][,req-limit=0][,fail-timeout=0,max-fail=0,][,weight=1][,backup]
+.BI "server=" address,secret[,auth-port=1812][,acct-port=1813][,bind-device=][,req-limit=0][,fail-timeout=0,max-fail=0,][,weight=1][,backup]
 Specifies IP address, secret, ports of RADIUS server.
+.br
+.B bind-device
+- device name or VRF to bind the connection. By default, the device name is undefined.
 .br
 .B req-limit
 - number of simultaneous requests to server (0 - unlimited).
@@ -845,8 +848,13 @@ Specifies IP address, secret, ports of RADIUS server.
 If you want to specify only authentication or accounting server then set auth-port/acct-port to zero.
 You may specify multiple radius servers.
 .TP
-.BI "dae-server=" x.x.x.x:port,secret
+.br
+.BI "dae-server=" x.x.x.x:port,secret[,bind-device=]
 Specifies IP address, port to bind and secret for Dynamic Authorization Extension server (DM/CoA).
+.br
+.B bind-device
+- device name or VRF to bind the connection. By default, the device name is undefined.
+.br
 .TP
 .BI "dm_coa_secret=" secret (deprecated, use dae-server instead)
 Specifies secret to use in DM/CoA communication.

--- a/accel-pppd/radius/dm_coa.c
+++ b/accel-pppd/radius/dm_coa.c
@@ -337,6 +337,13 @@ static void init(void)
 		return;
 	}
 
+	if ( !conf_dm_coa_vrf_default && ( 0 > setsockopt(serv.hnd.fd, SOL_SOCKET, SO_BINDTODEVICE, conf_dm_coa_vrf_name, strlen(conf_dm_coa_vrf_name)) ) )
+        {
+		log_emerg("radius:dm_coa: failed set vrf '%s' in setsockopt: %s\n", conf_dm_coa_vrf_name, strerror(errno));
+		close(serv.hnd.fd);
+		return;
+	}
+
 	fcntl(serv.hnd.fd, F_SETFD, fcntl(serv.hnd.fd, F_GETFD) | FD_CLOEXEC);
 
 	addr.sin_family = AF_INET;

--- a/accel-pppd/radius/dm_coa.c
+++ b/accel-pppd/radius/dm_coa.c
@@ -337,9 +337,9 @@ static void init(void)
 		return;
 	}
 
-	if ( !conf_dm_coa_vrf_default && ( 0 > setsockopt(serv.hnd.fd, SOL_SOCKET, SO_BINDTODEVICE, conf_dm_coa_vrf_name, strlen(conf_dm_coa_vrf_name)) ) )
+	if ( !conf_dm_coa_bind_default && ( 0 > setsockopt(serv.hnd.fd, SOL_SOCKET, SO_BINDTODEVICE, conf_dm_coa_bind_device, strlen(conf_dm_coa_bind_device)) ) )
         {
-		log_emerg("radius:dm_coa: failed set vrf '%s' in setsockopt: %s\n", conf_dm_coa_vrf_name, strerror(errno));
+		log_emerg("radius:dm_coa: failed set bind device '%s' in setsockopt: %s\n", conf_dm_coa_bind_device, strerror(errno));
 		close(serv.hnd.fd);
 		return;
 	}

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -38,6 +38,8 @@ int conf_interim_verbose;
 in_addr_t conf_dm_coa_server;
 int conf_dm_coa_port = 3799;
 char *conf_dm_coa_secret;
+char conf_dm_coa_vrf_name[IFNAMSIZ];
+unsigned int conf_dm_coa_vrf_default;
 
 int conf_sid_in_auth;
 int conf_require_nas_ident;
@@ -934,10 +936,10 @@ static struct pwdb_t pwdb = {
 	.check = rad_pwdb_check,
 };
 
-static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secret)
+static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secret, char *vrf_name, unsigned int *vrf_default)
 {
 	char *str = _strdup(opt);
-	char *p1, *p2;
+	char *p1, *p2, *p3;
 
 	p1 = strstr(str, ":");
 	p2 = strstr(str, ",");
@@ -950,6 +952,20 @@ static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secr
 		_free(str);
 		return -1;
 	}
+
+	p3 = strstr(p2 + 1, ",vrf=");
+	if (p3)
+	{
+		*p3 = 0;
+		if ( strlen(p3 + 5) > IFNAMSIZ - 1 )
+		{
+			_free(str);
+			return -1;
+		}
+		strcpy ( vrf_name, p3 + 5);
+		*vrf_default = 0;
+	} else
+		*vrf_default = 1;
 
 	*addr = inet_addr(str);
 
@@ -1019,7 +1035,7 @@ static int load_config(void)
 		conf_bind = conf_nas_ip_address;
 
 	opt = conf_get_opt("radius", "dae-server");
-	if (opt && parse_server(opt, &conf_dm_coa_server, &conf_dm_coa_port, &conf_dm_coa_secret)) {
+	if (opt && parse_server(opt, &conf_dm_coa_server, &conf_dm_coa_port, &conf_dm_coa_secret, conf_dm_coa_vrf_name, &conf_dm_coa_vrf_default)) {
 		log_emerg("radius: failed to parse dae-server\n");
 		return -1;
 	}

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -38,8 +38,8 @@ int conf_interim_verbose;
 in_addr_t conf_dm_coa_server;
 int conf_dm_coa_port = 3799;
 char *conf_dm_coa_secret;
-char conf_dm_coa_vrf_name[IFNAMSIZ];
-unsigned int conf_dm_coa_vrf_default;
+char conf_dm_coa_bind_device[IFNAMSIZ];
+unsigned int conf_dm_coa_bind_default;
 
 int conf_sid_in_auth;
 int conf_require_nas_ident;
@@ -936,7 +936,7 @@ static struct pwdb_t pwdb = {
 	.check = rad_pwdb_check,
 };
 
-static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secret, char *vrf_name, unsigned int *vrf_default)
+static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secret, char *bind_device, unsigned int *bind_default)
 {
 	char *str = _strdup(opt);
 	char *p1, *p2, *p3;
@@ -953,19 +953,19 @@ static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secr
 		return -1;
 	}
 
-	p3 = strstr(p2 + 1, ",vrf=");
+	p3 = strstr(p2 + 1, ",bind-device=");
 	if (p3)
 	{
 		*p3 = 0;
-		if ( strlen(p3 + 5) > IFNAMSIZ - 1 )
+		if ( strlen(p3 + 13) > IFNAMSIZ - 1 )
 		{
 			_free(str);
 			return -1;
 		}
-		strcpy ( vrf_name, p3 + 5);
-		*vrf_default = 0;
+		strcpy ( bind_device, p3 + 13);
+		*bind_default = 0;
 	} else
-		*vrf_default = 1;
+		*bind_default = 1;
 
 	*addr = inet_addr(str);
 
@@ -1035,7 +1035,7 @@ static int load_config(void)
 		conf_bind = conf_nas_ip_address;
 
 	opt = conf_get_opt("radius", "dae-server");
-	if (opt && parse_server(opt, &conf_dm_coa_server, &conf_dm_coa_port, &conf_dm_coa_secret, conf_dm_coa_vrf_name, &conf_dm_coa_vrf_default)) {
+	if (opt && parse_server(opt, &conf_dm_coa_server, &conf_dm_coa_port, &conf_dm_coa_secret, conf_dm_coa_bind_device, &conf_dm_coa_bind_default)) {
 		log_emerg("radius: failed to parse dae-server\n");
 		return -1;
 	}

--- a/accel-pppd/radius/radius.h
+++ b/accel-pppd/radius/radius.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <sys/time.h>
 
+#include <linux/if.h>           /* For IFNAMSIZ */
+
 #include "ap_session.h"
 #include "list.h"
 

--- a/accel-pppd/radius/radius_p.h
+++ b/accel-pppd/radius/radius_p.h
@@ -128,6 +128,8 @@ struct rad_server_t {
 	int queue_cnt;
 	int fail_timeout;
 	int max_fail;
+	char vrf_name[IFNAMSIZ];
+	unsigned int vrf_default:1;
 
 	struct list_head req_queue[2];
 	int client_cnt[2];
@@ -181,6 +183,8 @@ extern in_addr_t conf_bind;
 extern in_addr_t conf_gw_ip_address;
 extern in_addr_t conf_auth_server;
 extern char *conf_dm_coa_secret;
+extern char conf_dm_coa_vrf_name[IFNAMSIZ];
+extern unsigned int conf_dm_coa_vrf_default;
 extern int conf_sid_in_auth;
 extern int conf_require_nas_ident;
 extern in_addr_t conf_dm_coa_server;

--- a/accel-pppd/radius/radius_p.h
+++ b/accel-pppd/radius/radius_p.h
@@ -128,9 +128,8 @@ struct rad_server_t {
 	int queue_cnt;
 	int fail_timeout;
 	int max_fail;
-	char vrf_name[IFNAMSIZ];
-	unsigned int vrf_default:1;
-
+	char bind_device[IFNAMSIZ];
+	unsigned int bind_default:1;
 	struct list_head req_queue[2];
 	int client_cnt[2];
 	time_t fail_time;
@@ -183,8 +182,8 @@ extern in_addr_t conf_bind;
 extern in_addr_t conf_gw_ip_address;
 extern in_addr_t conf_auth_server;
 extern char *conf_dm_coa_secret;
-extern char conf_dm_coa_vrf_name[IFNAMSIZ];
-extern unsigned int conf_dm_coa_vrf_default;
+extern char conf_dm_coa_bind_device[IFNAMSIZ];
+extern unsigned int conf_dm_coa_bind_default;
 extern int conf_sid_in_auth;
 extern int conf_require_nas_ident;
 extern in_addr_t conf_dm_coa_server;

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -290,7 +290,7 @@ static int make_socket(struct rad_req_t *req)
 	addr.sin_addr.s_addr = req->server_addr;
 	addr.sin_port = htons(req->server_port);
 
-	if ( req->serv && !req->serv->vrf_default && ( 0 > setsockopt(req->hnd.fd, SOL_SOCKET, SO_BINDTODEVICE, req->serv->vrf_name, strlen(req->serv->vrf_name)) ) )
+	if ( req->serv && !req->serv->bind_default && ( 0 > setsockopt(req->hnd.fd, SOL_SOCKET, SO_BINDTODEVICE, req->serv->bind_device, strlen(req->serv->bind_device)) ) )
 	{
 		log_ppp_error("radius:setsockopt: %s\n", strerror(errno));
 		goto out_err;

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -290,6 +290,12 @@ static int make_socket(struct rad_req_t *req)
 	addr.sin_addr.s_addr = req->server_addr;
 	addr.sin_port = htons(req->server_port);
 
+	if ( req->serv && !req->serv->vrf_default && ( 0 > setsockopt(req->hnd.fd, SOL_SOCKET, SO_BINDTODEVICE, req->serv->vrf_name, strlen(req->serv->vrf_name)) ) )
+	{
+		log_ppp_error("radius:setsockopt: %s\n", strerror(errno));
+		goto out_err;
+	}
+
 	if (connect(req->hnd.fd, (struct sockaddr *) &addr, sizeof(addr))) {
 		log_ppp_error("radius:connect: %s\n", strerror(errno));
 		goto out_err;

--- a/accel-pppd/radius/serv.c
+++ b/accel-pppd/radius/serv.c
@@ -546,8 +546,8 @@ static void __add_server(struct rad_server_t *s)
 			s1->req_limit = s->req_limit;
 			s1->max_fail = s->max_fail;
 			s1->need_free = 0;
-			s1->vrf_default = s->vrf_default;
-			strcpy(s1->vrf_name, s->vrf_name);
+			s1->bind_default = s->bind_default;
+			strcpy(s1->bind_device, s->bind_device);
 			_free(s);
 			return;
 		}
@@ -679,7 +679,7 @@ static void add_server_old(void)
 	s->fail_timeout = conf_fail_timeout;
 	s->req_limit = conf_req_limit;
 	s->max_fail = conf_max_fail;
-	s->vrf_default = 1;
+	s->bind_default = 1;
 
 	if (auth_addr == acct_addr && !strcmp(auth_secret, acct_secret)) {
 		s->acct_port = acct_port;
@@ -698,7 +698,7 @@ static void add_server_old(void)
 		s->fail_timeout = conf_fail_timeout;
 		s->req_limit = conf_req_limit;
 		s->max_fail = conf_max_fail;
-		s->vrf_default = 1;
+		s->bind_default = 1;
 		__add_server(s);
 	}
 }
@@ -749,7 +749,7 @@ static int parse_server1(const char *_opt, struct rad_server_t *s)
 	s->fail_timeout = conf_fail_timeout;
 	s->req_limit = conf_req_limit;
 	s->max_fail = conf_max_fail;
-	s->vrf_default = 1;
+	s->bind_default = 1;
 
 	return 0;
 
@@ -833,22 +833,22 @@ static int parse_server2(const char *_opt, struct rad_server_t *s)
 	} else
 		s->weight = 1;
 
-	ptr3 = strstr(ptr2, ",vrf=");
+	ptr3 = strstr(ptr2, ",bind-device=");
 	if (ptr3) {
-		endptr = strchrnul(ptr3 + 5, ',');
+		endptr = strchrnul(ptr3 + 13, ',');
 		if (*endptr != ',' && *endptr != 0)
 			goto out;
-		if  ( ( endptr - ptr3 - 5 ) >  IFNAMSIZ - 1 ) {
-			log_error("radius: %s: too long vrf name, set vrf to default\n", _opt);
-			s->vrf_default = 1;
+		if  ( ( endptr - ptr3 - 13 ) >  IFNAMSIZ - 1 ) {
+			log_error("radius: %s: too long bind device name\n", _opt);
+			s->bind_default = 1;
 		} else
 		{
-			s->vrf_default = 0;
-			bzero(s->vrf_name, sizeof(s->vrf_name));
-			strncpy(s->vrf_name, ptr3 + 5, endptr - ptr3 - 5);
+			s->bind_default = 0;
+			bzero(s->bind_device, sizeof(s->bind_device));
+			strncpy(s->bind_device, ptr3 + 13, endptr - ptr3 - 13);
 		}
 	} else
-		s->vrf_default = 1;
+		s->bind_default = 1;
 
 	ptr3 = strstr(ptr2, ",backup");
 	if (ptr3)


### PR DESCRIPTION
New configuration format:

```
[radius]
server=address,secret[,auth-port=1812][,acct-port=1813][,vrf=VRF_NAME][,req-limit=0][,fail-timeout=0,max-fail=0,][,weight=1][,backup]
dae-server=x.x.x.x:port,secret[,vrf=VRF_NAME]
```

By default, VRF name is undefined.