### PR TITLE
add switch to disable sending NAS-Port-Id

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -219,6 +219,7 @@ verbose=1
 #default-realm=
 #strip-realm=0
 #attr-tunnel-type=My-Tunnel-Type
+#nas-port-id-in-req=1
 
 [client-ip-range]
 10.0.0.0/8

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -904,6 +904,9 @@ option for realm substitution.
 .TP
 .BI "sid-in-auth=0|1"
 Specifies should accel-ppp generate and send Acct-Session-Id on Access-Request packet.
+.TP
+.BI "nas-port-id-in-req=" 0|1
+Specifies should accel-ppp send NAS-Port-Id on Access-Request and Accounting-Request packets (default 1).
 .SH [log]
 .br
 Configuration of log and log_file modules.

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -42,6 +42,7 @@ char conf_dm_coa_bind_device[IFNAMSIZ];
 unsigned int conf_dm_coa_bind_default;
 
 int conf_sid_in_auth;
+int conf_nas_port_id_in_req = 1;
 int conf_require_nas_ident;
 int conf_acct_interim_interval;
 int conf_acct_interim_jitter;
@@ -1069,6 +1070,10 @@ static int load_config(void)
 	opt = conf_get_opt("radius", "strip-realm");
 	if (opt && atoi(opt) >= 0)
 		conf_strip_realm = atoi(opt) > 0;
+
+	opt = conf_get_opt("radius", "nas-port-id-in-req");
+	if (opt)
+		conf_nas_port_id_in_req = atoi(opt);
 
 	return 0;
 }

--- a/accel-pppd/radius/radius_p.h
+++ b/accel-pppd/radius/radius_p.h
@@ -185,6 +185,7 @@ extern char *conf_dm_coa_secret;
 extern char conf_dm_coa_bind_device[IFNAMSIZ];
 extern unsigned int conf_dm_coa_bind_default;
 extern int conf_sid_in_auth;
+extern int conf_nas_port_id_in_req;
 extern int conf_require_nas_ident;
 extern in_addr_t conf_dm_coa_server;
 extern int conf_dm_coa_port;

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -89,8 +89,10 @@ static struct rad_req_t *__rad_req_alloc(struct radius_pd_t *rpd, int code, cons
 	if (rpd->ses->unit_idx != -1 && rad_packet_add_int(req->pack, NULL, "NAS-Port", rpd->ses->unit_idx))
 		goto out_err;
 
-	if (*rpd->ses->ifname && rad_packet_add_str(req->pack, NULL, "NAS-Port-Id", rpd->ses->ifname))
-		goto out_err;
+	if (conf_nas_port_id_in_req) {
+		if (*rpd->ses->ifname && rad_packet_add_str(req->pack, NULL, "NAS-Port-Id", rpd->ses->ifname))
+			goto out_err;
+	}
 
 	if (req->rpd->ses->ctrl->type == CTRL_TYPE_IPOE) {
 		if (rad_packet_add_val(req->pack, NULL, "NAS-Port-Type", "Ethernet"))


### PR DESCRIPTION
This patch introduces nas-port-id-in-req switch to disable sending
NAS-Port-Id attribute in radauth and radacct messages. New switch
might be useful if radius server cannot properly handle this
attrubite.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>