### PR TITLE
Use helper method to set ipoe device function

### DIFF
--- a/drivers/ipoe/ipoe.c
+++ b/drivers/ipoe/ipoe.c
@@ -1154,7 +1154,11 @@ static int ipoe_create(__be32 peer_addr, __be32 addr, __be32 gw, int ifindex, co
 
 	if (link_dev) {
 		dev->features = link_dev->features & ~(NETIF_F_HW_VLAN_FILTER | NETIF_F_LRO);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
+		dev_addr_mod(dev, 0, link_dev->dev_addr, ETH_ALEN);
+#else
 		memcpy(dev->dev_addr, link_dev->dev_addr, ETH_ALEN);
+#endif
 		memcpy(dev->broadcast, link_dev->broadcast, ETH_ALEN);
 	}
 
@@ -1446,7 +1450,11 @@ static int ipoe_nl_cmd_modify(struct sk_buff *skb, struct genl_info *info)
 
 		if (link_dev) {
 			ses->dev->features = link_dev->features & ~(NETIF_F_HW_VLAN_FILTER | NETIF_F_LRO);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
+			dev_addr_mod(dev, 0, link_dev->dev_addr, ETH_ALEN);
+#else
 			memcpy(dev->dev_addr, link_dev->dev_addr, ETH_ALEN);
+#endif
 			memcpy(dev->broadcast, link_dev->broadcast, ETH_ALEN);
 		}
 	}


### PR DESCRIPTION
This patch fixes a compile error on linux kernel >= 5.15

In kernel 5.15, data type of `netdev->dev_addr` has been changed to `const unsigned char*` 
The new helper method `dev_addr_mod` must be used to set the value instead of setting directly by `memcpy`.