### PR TITLE
Disable vlan timeout

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -449,7 +449,7 @@ parameter specifies list of vlans or ranges of vlans to monitor for and may be i
 vlan-mon=eth1,2,5,10,20-30
 .TP
 .BI "vlan-timeout=" n
-Specifies time of vlan inactivity before it will be removed (seconds).
+Specifies time of vlan inactivity before it will be removed (seconds) (default 60). A value of -1 disables removal of inactive vlan.
 .TP
 .BI "vlan-name=" pattern
 Specifies pattern of vlan interface name. Pattern may contain following macros:

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -2804,7 +2804,8 @@ void ipoe_vlan_mon_notify(int ifindex, int vid, int vlan_ifindex)
 			if (serv->ifindex == vlan_ifindex) {
 				if (!serv->vlan_mon) {
 					serv->vlan_mon = 1;
-					set_vlan_timeout(serv);
+					if(conf_vlan_timeout > 0)
+						set_vlan_timeout(serv);
 				}
 				pthread_mutex_unlock(&serv_lock);
 				return;
@@ -3253,7 +3254,8 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 
 	if (vlan_mon) {
 		serv->vlan_mon = 1;
-		set_vlan_timeout(serv);
+		if(conf_vlan_timeout > 0)
+			set_vlan_timeout(serv);
 	}
 
 	if (opt_mtu)
@@ -3614,7 +3616,8 @@ static void add_vlan_mon(const char *opt, long *mask)
 
 			if (!serv->vlan_mon) {
 				serv->vlan_mon = 1;
-				set_vlan_timeout(serv);
+				if(conf_vlan_timeout > 0)
+					set_vlan_timeout(serv);
 			}
 		}
 	}
@@ -3647,7 +3650,8 @@ static int __load_vlan_mon_re(int index, int flags, const char *name, int iflink
 
 			if (!serv->vlan_mon) {
 				serv->vlan_mon = 1;
-				set_vlan_timeout(serv);
+				if(conf_vlan_timeout > 0)
+					set_vlan_timeout(serv);
 			}
 		}
 	}
@@ -4009,7 +4013,7 @@ static void load_config(void)
 		conf_proto = 3;
 
 	opt = conf_get_opt("ipoe", "vlan-timeout");
-	if (opt && atoi(opt) > 0)
+	if (opt && (atoi(opt) > 0 || atoi(opt) == -1))
 		conf_vlan_timeout = atoi(opt);
 	else
 		conf_vlan_timeout = 60;


### PR DESCRIPTION
This PR allows setting vlan_timeout=-1 which disables all vlan timeouts to allow dynamic vlan creation without removing vlans after a timeout. Currently only implemented for ipoe and not pppoe.