### PR TITLE
Fix ipv6 inside netns

### DIFF
--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -76,7 +76,10 @@ static void ev_ses_started(struct ap_session *ses)
 	if (a->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&a->addr))
 		return;
 
+	net->enter_ns();
 	sock = net->socket(AF_INET6, SOCK_DGRAM, 0);
+	net->exit_ns();
+
 	if (!sock) {
 		log_ppp_error("dhcpv6: socket: %s\n", strerror(errno));
 		return;

--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -88,7 +88,7 @@ static void ev_ses_started(struct ap_session *ses)
 	net->setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &f, sizeof(f));
 
 	if (net->setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, ses->ifname, strlen(ses->ifname))) {
-		log_ppp_error("ipv6_nd: setsockopt(SO_BINDTODEVICE): %s\n", strerror(errno));
+		log_ppp_error("dhcpv6: setsockopt(SO_BINDTODEVICE): %s\n", strerror(errno));
 		close(sock);
 		return;
 	}

--- a/accel-pppd/ipv6/nd.c
+++ b/accel-pppd/ipv6/nd.c
@@ -284,7 +284,9 @@ static int ipv6_nd_start(struct ap_session *ses)
 	int val;
 	struct ipv6_nd_handler_t *h;
 
+	net->enter_ns();
 	sock = net->socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+	net->exit_ns();
 
 	if (sock < 0) {
 		log_ppp_error("socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6): %s\n", strerror(errno));


### PR DESCRIPTION
# About this PR :
The ipv6 configuration via accel-ppp does not go as expected when the link ends in a given namespace (other than the default) because the ipv6 socket is always created in the default namespace. 
This pr fix ipv6 socket creation for these 2 modules : ipv6_nd and ipv6_dhcp, when link is terminated inside netns. I tested 671c54b on the current master branch (also in the version also 2.11) and it's work as i expected but i don't test the commit 26270ec for the moment(in progress).

# To produce issue :

CPE, COLLECT and ROUTER run on linux distribution (network oriented) based on debian.
I simulate this network infrastructure :  CPE --pppoe-- COLLECT--l2tp-- ROUTER

*Freeradius configuration on the ROUTER*
<pre>
site1@client1.telco Cleartext-Password := 'passl2tp', Auth-Type := Accept
 Framed-IP-Address = "10.0.0.101",
 NAS-Port-ID = "ppp001000",
 Framed-IPv6-Prefix = 2001:db8:ff00:1::/64
</pre> 
 
*visualization of the tunnel interface on the ROUTER side*

<pre>
9183: ppp001000: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1420 qdisc pfifo_fast state UNKNOWN group default qlen 3
    link/ppp
    inet 11.11.11.11 peer 10.0.0.101/32 scope global ppp001000
       valid_lft forever preferred_lft forever
    inet6 2001:db8:ff00:1:e9f5:7a28:df5:941c/64 scope global nodad
       valid_lft forever preferred_lft forever
    inet6 fe80::e9f5:7a28:df5:941c/64 scope link
       valid_lft forever preferred_lft forever
</pre>

*Changed the freeradius configuration to end the link in a namespace (red in this example)*

<pre>
 # site1 - client1 - client1
 site1@client1.telco Cleartext-Password := 'passl2tp', Auth-Type := Accept
 Framed-IP-Address = "10.0.0.101",
 NAS-Port-ID = "red/ppp001000",
 Framed-IPv6-Prefix = 2001:db8:ff00:1::/64
</pre>

*Visualization of the tunnel interface on the Router side in the namespace*

<pre>
9191: ppp001000@if9191: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1420 qdisc pfifo_fast state UNKNOWN group default qlen 3
    link/ppp  link-netnsid 0
    inet 11.11.11.11 peer 10.0.0.101/32 scope global ppp001000
       valid_lft forever preferred_lft forever
    inet6 fe80::de8d:150c:cfff:793d/64 scope link
       valid_lft forever preferred_lft forever
</pre>
We don't have ipv6 auto-configuration 

# Trace log in Router :
In log file, we read this error when the link is terminated inside RED netns
<pre>
accel-pppd: ppp001002:site2@client1.telco: ipv6_nd: setsockopt(SO_BINDTODEVICE): No such device
</pre>

It seems the issue is that accel-ppp (ipv6) thinks the interface is still in the NS default, hence the @No such device@

