### PR TITLE
ci: add build jobs (Github CI) 

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -1,0 +1,167 @@
+name: Build and Run
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  Build-in-VM:
+    #if: ${{ false }} # disable for now
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: ["ubuntu-22.04", "ubuntu-20.04"]
+    runs-on: ${{ matrix.distro }}
+    steps:
+      - name: Set vars for Ubuntu 20.04
+        if: ${{ matrix.distro == 'ubuntu-20.04' }}
+        run: |
+          echo "DISTRO=ubuntu20.04" >> $GITHUB_ENV
+          echo "CPACK_TYPE=Ubuntu20" >> $GITHUB_ENV
+      - name: Set vars for Ubuntu 22.04
+        if: ${{ matrix.distro == 'ubuntu-22.04' }}
+        run: |
+          echo "DISTRO=ubuntu22.04" >> $GITHUB_ENV
+          echo "CPACK_TYPE=Ubuntu20" >> $GITHUB_ENV
+      - name: Set common vars
+        run: |
+          echo UNAME_R=`uname -r` >> $GITHUB_ENV
+          echo UNAME_M=`uname -m` >> $GITHUB_ENV;
+      - name: Install build tools
+        run: >
+          sudo apt update && 
+          sudo apt -y install git build-essential cmake gcc linux-headers-`uname -r` 
+          libpcre3-dev libssl-dev liblua5.1-0-dev kmod
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: mkdir build
+        run: mkdir build
+      - name: cmake
+        working-directory: ./build
+        run: >
+          cmake -DBUILD_IPOE_DRIVER=TRUE -DBUILD_VLAN_MON_DRIVER=TRUE -DCMAKE_INSTALL_PREFIX=/usr 
+          -DKDIR=/usr/src/linux-headers-`uname -r` 
+          -DLUA=TRUE -DSHAPER=FALSE -DRADIUS=TRUE 
+          -DCPACK_TYPE=${{ env.CPACK_TYPE }} ..
+      - name: make
+        working-directory: ./build
+        run: make
+      - name: Generate debian package
+        working-directory: ./build
+        run: cpack -G DEB
+      - name: Rename accel-ppp deb package
+        working-directory: ./build
+        run: >
+          mv -v accel-ppp.deb 
+          accel-ppp_`git describe --tags --long | sed 's/^v//' | sed 's/-/+/' | sed 's/-/~/'`-1+${{ env.DISTRO }}_`uname -m`.deb
+      - name: Install debian package
+        working-directory: ./build
+        run: sudo apt -y install ./accel-ppp*.deb
+      - name: Copy default config
+        run: sudo cp /etc/accel-ppp.conf.dist /etc/accel-ppp.conf
+      - name: Start accel-ppp
+        run: sudo systemctl start accel-ppp
+      - name: Check accel-ppp running status
+        run: sudo systemctl status accel-ppp
+      - name: Check accel-ppp stat
+        run: accel-cmd show stat
+      - name: Upload .deb package as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: deb-package-${{ matrix.distro }}-${{ env.UNAME_M }}-${{ env.UNAME_R }}
+          path: build/accel-ppp_*.deb
+          if-no-files-found: error
+
+  Build-in-Container:
+    #if: ${{ false }} # disable for now
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          [
+            "debian:10",
+            "debian:11",
+            "debian:bookworm",
+            "ubuntu:18.04",
+            "ubuntu:20.04",
+            "ubuntu:22.04",
+          ]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.distro }}
+    steps:
+      - name: Set distro-specific vars
+        run: >
+          HEADERS_SUFFIX=`uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/`;
+          DISTRO=`echo ${{ matrix.distro }} |  sed 's/://'`;
+          case "${{ matrix.distro }}" in
+          debian:bookworm) DISTRO=debian12; CPACK_TYPE=Debian12 ;;
+          debian:11) CPACK_TYPE=Debian11 ;;
+          debian:10) CPACK_TYPE=Debian10 ;;
+          ubuntu:22.04) CPACK_TYPE=Ubuntu22 ; HEADERS_SUFFIX=generic ;;
+          ubuntu:20.04) CPACK_TYPE=Ubuntu20 ; HEADERS_SUFFIX=generic ;;
+          ubuntu:18.04) CPACK_TYPE=Ubuntu18 ; HEADERS_SUFFIX=generic ;;
+          esac;
+          echo HEADERS_SUFFIX=$HEADERS_SUFFIX >> $GITHUB_ENV;
+          echo DISTRO=$DISTRO >> $GITHUB_ENV;
+          echo CPACK_TYPE=$CPACK_TYPE >> $GITHUB_ENV;
+          echo UNAME_M=`uname -m` >> $GITHUB_ENV;
+          cat $GITHUB_ENV
+      - name: Install build tools
+        run: >
+          apt update && apt -y upgrade && apt -y dist-upgrade &&
+          DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt -y install git build-essential cmake gcc 
+          linux-headers-${{ env.HEADERS_SUFFIX }}
+          libpcre3-dev libssl-dev liblua5.1-0-dev kmod
+      - name: Get kernel name from headers
+        run: >
+          echo KERNEL_NAME=`ls -1 /usr/src/ | grep  'linux-headers.*${{ env.HEADERS_SUFFIX }}' | 
+          sed 's/linux-headers-//'` >> $GITHUB_ENV;
+          cat $GITHUB_ENV
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: mkdir build
+        run: mkdir build
+      - name: Disable git security warnings
+        run: git config --global --add safe.directory '*'
+      - name: cmake
+        working-directory: ./build
+        run: >
+          cmake -DBUILD_IPOE_DRIVER=TRUE -DBUILD_VLAN_MON_DRIVER=TRUE -DCMAKE_INSTALL_PREFIX=/usr 
+          -DKDIR=/usr/src/linux-headers-${{ env.KERNEL_NAME }}
+          -DMODULES_KDIR=${{ env.KERNEL_NAME }}
+          -DLUA=TRUE -DSHAPER=FALSE -DRADIUS=TRUE 
+          -DCPACK_TYPE=${{ env.CPACK_TYPE }} ..
+      - name: make
+        working-directory: ./build
+        run: make
+      - name: Generate debian package
+        working-directory: ./build
+        run: cpack -G DEB
+      - name: Rename accel-ppp deb package
+        working-directory: ./build
+        run: >
+          mv -v accel-ppp.deb 
+          accel-ppp_`git describe --tags --long | sed 's/^v//' | sed 's/-/+/' | sed 's/-/~/'`-1+${{ env.DISTRO }}_${{ env.UNAME_M }}.deb
+      - name: Install debian package
+        working-directory: ./build
+        run: apt -y install ./accel-ppp*.deb
+      - name: Start accel-ppp with default config
+        run: accel-pppd -d -c /etc/accel-ppp.conf.dist
+      - name: Sleep for 1 sec
+        run: sleep 1
+      - name: Check accel-ppp stat
+        run: accel-cmd show stat
+      - name: Upload .deb package as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: deb-package-${{ env.DISTRO }}-${{ env.UNAME_M }}-${{ env.KERNEL_NAME }}
+          path: build/accel-ppp_*.deb
+          if-no-files-found: error

--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -48,6 +48,11 @@ IF(CPACK_TYPE STREQUAL Debian11)
 	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
 ENDIF(CPACK_TYPE STREQUAL Debian11)
 
+IF(CPACK_TYPE STREQUAL Debian12)
+	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.34), libssl3 (>= 3.0.5), libpcre3 (>= 8.39)")
+	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
+ENDIF(CPACK_TYPE STREQUAL Debian12)
+
 IF(CPACK_TYPE STREQUAL Ubuntu16)
 	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.23), libssl1.0.0 (>= 1.0.0), libpcre3 (>= 8.39)")
 	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
@@ -62,6 +67,11 @@ IF(CPACK_TYPE STREQUAL Ubuntu20)
         SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.31), libssl1.1 (>= 1.1.1d), libpcre3 (>= 8.39)")
         INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
 ENDIF(CPACK_TYPE STREQUAL Ubuntu20)
+
+IF(CPACK_TYPE STREQUAL Ubuntu22)
+        SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.35), libssl3 (>= 3.0.2), libpcre3 (>= 8.39)")
+        INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
+ENDIF(CPACK_TYPE STREQUAL Ubuntu22)
 
 IF(CPACK_TYPE STREQUAL Centos7)
 	SET(CPACK_RPM_PACKAGE_LICENSE "GPL")


### PR DESCRIPTION
This PR includes two commits:

1. build: add deb packaging support for Ubuntu 22.04 and Debian 12
2. ci: add build jobs (Github CI)

First commit is required for the second one.
Full description is in the second commit (ci: add build jobs (Github CI))

CI run results (artifacts & logs) can be reviewed here:  https://github.com/svlobanov/accel-ppp/actions/runs/2968158823 (CI run results will be removed after 90 days by github)