### PR TITLE
T72: Fix compilations warnings for unaligned variable access

### DIFF
--- a/accel-pppd/ctrl/ipoe/CMakeLists.txt
+++ b/accel-pppd/ctrl/ipoe/CMakeLists.txt
@@ -1,4 +1,5 @@
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member")
 
 SET(sources
 	ipoe.c

--- a/accel-pppd/ctrl/pppoe/CMakeLists.txt
+++ b/accel-pppd/ctrl/pppoe/CMakeLists.txt
@@ -1,4 +1,5 @@
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member")
 
 SET(sources
 	pppoe.c

--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -244,8 +244,8 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 	struct dhcpv6_opt_ia_na *ia_na;
 	struct dhcpv6_opt_ia_addr *ia_addr;
 	struct dhcpv6_opt_ia_prefix *ia_prefix;
+	struct in6_addr addr, prefix;
 	struct ipv6db_addr_t *a;
-	struct in6_addr addr;
 	struct ap_session *ses = req->ses;
 	int f = 0, f1, f2 = 0;
 
@@ -282,7 +282,8 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 					opt2 = dhcpv6_nested_option_alloc(reply, opt1, D6_OPTION_IAADDR, sizeof(*ia_addr) - sizeof(struct dhcpv6_opt_hdr));
 					ia_addr = (struct dhcpv6_opt_ia_addr *)opt2->hdr;
 
-					build_ip6_addr(a, ses->ipv6->peer_intf_id, &ia_addr->addr);
+					build_ip6_addr(a, ses->ipv6->peer_intf_id, &addr);
+					memcpy(&ia_addr->addr, &addr, sizeof(addr));
 
 					ia_addr->pref_lifetime = htonl(conf_pref_lifetime);
 					ia_addr->valid_lifetime = htonl(conf_valid_lifetime);
@@ -309,8 +310,9 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 					list_for_each_entry(opt2, &opt->opt_list, entry) {
 						if (ntohs(opt2->hdr->code) == D6_OPTION_IAADDR) {
 							ia_addr = (struct dhcpv6_opt_ia_addr *)opt2->hdr;
+							addr = ia_addr->addr;
 
-							if (IN6_IS_ADDR_UNSPECIFIED(&ia_addr->addr))
+							if (IN6_IS_ADDR_UNSPECIFIED(&addr))
 								continue;
 
 							f1 = 0;
@@ -389,8 +391,9 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 					list_for_each_entry(opt2, &opt->opt_list, entry) {
 						if (ntohs(opt2->hdr->code) == D6_OPTION_IAPREFIX) {
 							ia_prefix = (struct dhcpv6_opt_ia_prefix *)opt2->hdr;
+							prefix = ia_prefix->prefix;
 
-							if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&ia_prefix->prefix))
+							if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&prefix))
 								continue;
 
 							f1 = 0;
@@ -464,7 +467,7 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 	struct dhcpv6_opt_ia_addr *ia_addr;
 	struct dhcpv6_opt_ia_prefix *ia_prefix;
 	struct ipv6db_addr_t *a;
-	struct in6_addr addr;
+	struct in6_addr addr, prefix;
 	struct ap_session *ses = req->ses;
 	int f = 0, f1, f2 = 0, f3;
 
@@ -488,8 +491,8 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 			list_for_each_entry(opt2, &opt->opt_list, entry) {
 				if (ntohs(opt2->hdr->code) == D6_OPTION_IAADDR) {
 					ia_addr = (struct dhcpv6_opt_ia_addr *)opt2->hdr;
-
-					if (IN6_IS_ADDR_UNSPECIFIED(&ia_addr->addr))
+					addr = ia_addr->addr;
+					if (IN6_IS_ADDR_UNSPECIFIED(&addr))
 						continue;
 
 					f1 = 0;
@@ -550,8 +553,9 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 			list_for_each_entry(opt2, &opt->opt_list, entry) {
 				if (ntohs(opt2->hdr->code) == D6_OPTION_IAPREFIX) {
 					ia_prefix = (struct dhcpv6_opt_ia_prefix *)opt2->hdr;
+					prefix = ia_prefix->prefix;
 
-					if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&ia_prefix->prefix))
+					if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&prefix))
 						continue;
 
 					f1 = 0;


### PR DESCRIPTION
- Suppress false-positive warnings for IPoE/PPPoE
- Introduce tmp variables to avoid alignment issues for SSTP/DHCPv6

https://phabricator.accel-ppp.org/T72