### PR TITLE
T72: Fix compilations warnings for unaligned variable access

### DIFF
--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -625,7 +625,7 @@ static int dhcpv4_send_raw(struct dhcpv4_serv *serv, struct dhcpv4_packet *pack,
 		struct iphdr ip;
 		struct udphdr udp;
 		uint8_t data[0];
-	} __packed *hdr;
+	} __packed __aligned(2) *hdr;
 	struct sockaddr_ll ll_addr;
 	int n, len = pack->ptr - pack->data;
 

--- a/accel-pppd/ctrl/ipoe/dhcpv4.h
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.h
@@ -8,6 +8,7 @@
 
 #include "triton.h"
 
+#define __aligned(n) __attribute__((aligned (n)))
 #define __packed __attribute__((packed))
 
 #define DHCP_SERV_PORT 67

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -433,6 +433,8 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 	return conn;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 static void connect_channel(struct pppoe_conn_t *conn)
 {
 	int sock;
@@ -486,6 +488,7 @@ out_err_close:
 out_err:
 	disconnect(conn);
 }
+#pragma GCC diagnostic pop
 
 static struct pppoe_conn_t *find_channel(struct pppoe_serv_t *serv, const uint8_t *cookie)
 {

--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -244,8 +244,8 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 	struct dhcpv6_opt_ia_na *ia_na;
 	struct dhcpv6_opt_ia_addr *ia_addr;
 	struct dhcpv6_opt_ia_prefix *ia_prefix;
+	struct in6_addr addr, prefix;
 	struct ipv6db_addr_t *a;
-	struct in6_addr addr;
 	struct ap_session *ses = req->ses;
 	int f = 0, f1, f2 = 0;
 
@@ -282,7 +282,8 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 					opt2 = dhcpv6_nested_option_alloc(reply, opt1, D6_OPTION_IAADDR, sizeof(*ia_addr) - sizeof(struct dhcpv6_opt_hdr));
 					ia_addr = (struct dhcpv6_opt_ia_addr *)opt2->hdr;
 
-					build_ip6_addr(a, ses->ipv6->peer_intf_id, &ia_addr->addr);
+					build_ip6_addr(a, ses->ipv6->peer_intf_id, &addr);
+					memcpy(&ia_addr->addr, &addr, sizeof(addr));
 
 					ia_addr->pref_lifetime = htonl(conf_pref_lifetime);
 					ia_addr->valid_lifetime = htonl(conf_valid_lifetime);
@@ -309,8 +310,9 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 					list_for_each_entry(opt2, &opt->opt_list, entry) {
 						if (ntohs(opt2->hdr->code) == D6_OPTION_IAADDR) {
 							ia_addr = (struct dhcpv6_opt_ia_addr *)opt2->hdr;
+							addr = ia_addr->addr;
 
-							if (IN6_IS_ADDR_UNSPECIFIED(&ia_addr->addr))
+							if (IN6_IS_ADDR_UNSPECIFIED(&addr))
 								continue;
 
 							f1 = 0;
@@ -389,8 +391,9 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 					list_for_each_entry(opt2, &opt->opt_list, entry) {
 						if (ntohs(opt2->hdr->code) == D6_OPTION_IAPREFIX) {
 							ia_prefix = (struct dhcpv6_opt_ia_prefix *)opt2->hdr;
+							prefix = ia_prefix->prefix;
 
-							if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&ia_prefix->prefix))
+							if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&prefix))
 								continue;
 
 							f1 = 0;
@@ -464,7 +467,7 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 	struct dhcpv6_opt_ia_addr *ia_addr;
 	struct dhcpv6_opt_ia_prefix *ia_prefix;
 	struct ipv6db_addr_t *a;
-	struct in6_addr addr;
+	struct in6_addr addr, prefix;
 	struct ap_session *ses = req->ses;
 	int f = 0, f1, f2 = 0, f3;
 
@@ -488,8 +491,8 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 			list_for_each_entry(opt2, &opt->opt_list, entry) {
 				if (ntohs(opt2->hdr->code) == D6_OPTION_IAADDR) {
 					ia_addr = (struct dhcpv6_opt_ia_addr *)opt2->hdr;
-
-					if (IN6_IS_ADDR_UNSPECIFIED(&ia_addr->addr))
+					addr = ia_addr->addr;
+					if (IN6_IS_ADDR_UNSPECIFIED(&addr))
 						continue;
 
 					f1 = 0;
@@ -550,8 +553,9 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 			list_for_each_entry(opt2, &opt->opt_list, entry) {
 				if (ntohs(opt2->hdr->code) == D6_OPTION_IAPREFIX) {
 					ia_prefix = (struct dhcpv6_opt_ia_prefix *)opt2->hdr;
+					prefix = ia_prefix->prefix;
 
-					if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&ia_prefix->prefix))
+					if (ia_prefix->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&prefix))
 						continue;
 
 					f1 = 0;


### PR DESCRIPTION
Hi @svlobanov! Sorry for the delayed response.
I had to recreate the pull request as the last one would not display my updates.
A more detailed description of what is going on will be on the phabricator.

```
- IPoE/DHCP4: Specify minimal, suitable alignment explicitly. 
  We need to guarantee 2-byte alignment for the `hdr` pointer in
    `ip_csum(uint16_t *buf)` calculation
- PPPOE: Suppress false-positive warning for `sockaddr_pppox`.
   Similar issue: https://github.com/kernelslacker/trinity/pull/40
- Introduce tmp variables to avoid alignment issues for SSTP/DHCPv6

For additional details:
https://phabricator.accel-ppp.org/T72

Signed-off-by: Volodymyr Huti <v.huti@vyos.io>
```

Although, I still need to do some testing on some real setups.
It would be great if somebody could help or provide some automated setups for sanity testing.
Sorry for the inconvenience, thanks!)