### PR TITLE
Use 64-bit interface statistics and some more env parameters for pppd-compat

### DIFF
--- a/accel-pppd/cli/show_sessions.c
+++ b/accel-pppd/cli/show_sessions.c
@@ -2,6 +2,7 @@
 #include <time.h>
 #include <string.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <arpa/inet.h>
 #include <linux/if_link.h>
@@ -52,7 +53,7 @@ struct cell_t
 static LIST_HEAD(col_list);
 static char *conf_def_columns = NULL;
 
-static __thread struct rtnl_link_stats stats;
+static __thread struct rtnl_link_stats64 stats;
 static __thread int stats_set;
 
 void __export cli_show_ses_register(const char *name, const char *desc, void (*print)(struct ap_session *ses, char *buf))
@@ -580,7 +581,7 @@ static void print_rx_bytes(struct ap_session *ses, char *buf)
 		get_stats(ses);
 		stats_set = 1;
 	}
-	format_bytes(buf, 4294967296ll*ses->acct_input_gigawords + stats.rx_bytes);
+	format_bytes(buf, stats.rx_bytes);
 }
 
 static void print_tx_bytes(struct ap_session *ses, char *buf)
@@ -589,7 +590,7 @@ static void print_tx_bytes(struct ap_session *ses, char *buf)
 		get_stats(ses);
 		stats_set = 1;
 	}
-	format_bytes(buf, 4294967296ll*ses->acct_output_gigawords + stats.tx_bytes);
+	format_bytes(buf, stats.tx_bytes);
 }
 
 static void print_rx_bytes_raw(struct ap_session *ses, char *buf)
@@ -598,7 +599,7 @@ static void print_rx_bytes_raw(struct ap_session *ses, char *buf)
 		get_stats(ses);
 		stats_set = 1;
 	}
-	sprintf(buf, "%llu", 4294967296ll*ses->acct_input_gigawords + stats.rx_bytes);
+	sprintf(buf, PRIu64, stats.rx_bytes);
 }
 
 static void print_tx_bytes_raw(struct ap_session *ses, char *buf)
@@ -607,7 +608,7 @@ static void print_tx_bytes_raw(struct ap_session *ses, char *buf)
 		get_stats(ses);
 		stats_set = 1;
 	}
-	sprintf(buf, "%llu", 4294967296ll*ses->acct_output_gigawords + stats.tx_bytes);
+	sprintf(buf, PRIu64, stats.tx_bytes);
 }
 
 static void print_rx_pkts(struct ap_session *ses, char *buf)
@@ -616,7 +617,7 @@ static void print_rx_pkts(struct ap_session *ses, char *buf)
 		get_stats(ses);
 		stats_set = 1;
 	}
-	sprintf(buf, "%u", stats.rx_packets);
+	sprintf(buf, PRIu64, stats.rx_packets);
 }
 
 static void print_tx_pkts(struct ap_session *ses, char *buf)
@@ -625,7 +626,7 @@ static void print_tx_pkts(struct ap_session *ses, char *buf)
 		get_stats(ses);
 		stats_set = 1;
 	}
-	sprintf(buf, "%u", stats.tx_packets);
+	sprintf(buf, PRIu64, stats.tx_packets);
 }
 
 static void load_config(void *data)

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -978,7 +978,7 @@ static int ppp_allocate_pty(int *master, int *slave, int flags)
 	struct termios tios;
 	int value, mfd, sfd;
 
-	if (openpty(&mfd, &sfd, NULL, &tios, NULL) < 0) {
+	if (openpty(&mfd, &sfd, NULL, NULL, NULL) < 0) {
 		log_ppp_error("sstp: allocate pty: %s\n", strerror(errno));
 		return -1;
 	}

--- a/accel-pppd/extra/pppd_compat.c
+++ b/accel-pppd/extra/pppd_compat.c
@@ -684,12 +684,11 @@ static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd)
 	}
 
 	if (pd->ses->stop_time) {
-		uint64_t gword_sz = (uint64_t)UINT32_MAX + 1;
 		uint64_t tx_bytes;
 		uint64_t rx_bytes;
 
-		tx_bytes = ses->acct_tx_bytes + gword_sz * ses->acct_output_gigawords;
-		rx_bytes = ses->acct_rx_bytes + gword_sz * ses->acct_input_gigawords;
+		tx_bytes = ses->acct_tx_bytes;
+		rx_bytes = ses->acct_rx_bytes;
 
 		env[n] = mem;
 		write_sz = snprintf(mem, mem_sz, "CONNECT_TIME=%lu",

--- a/accel-pppd/extra/pppd_compat.c
+++ b/accel-pppd/extra/pppd_compat.c
@@ -30,7 +30,7 @@
 #include "memdebug.h"
 
 #define ENV_MEM 1024
-#define ENV_MAX 16
+#define ENV_MAX 32
 
 static char *conf_ip_up;
 static char *conf_ip_pre_up;
@@ -686,9 +686,13 @@ static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd)
 	if (pd->ses->stop_time) {
 		uint64_t tx_bytes;
 		uint64_t rx_bytes;
+		uint64_t tx_packets;
+		uint64_t rx_packets;
 
 		tx_bytes = ses->acct_tx_bytes;
 		rx_bytes = ses->acct_rx_bytes;
+		tx_packets = ses->acct_tx_packets;
+		rx_packets = ses->acct_rx_packets;
 
 		env[n] = mem;
 		write_sz = snprintf(mem, mem_sz, "CONNECT_TIME=%lu",
@@ -712,6 +716,24 @@ static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd)
 		env[n] = mem;
 		write_sz = snprintf(mem, mem_sz, "BYTES_RCVD=%" PRIu64,
 				    rx_bytes);
+		if (write_sz < 0 || write_sz >= mem_sz)
+			goto out;
+		mem_sz -= write_sz + 1;
+		mem += write_sz + 1;
+		++n;
+
+		env[n] = mem;
+		write_sz = snprintf(mem, mem_sz, "PACKETS_SENT=%" PRIu64,
+			tx_packets);
+		if (write_sz < 0 || write_sz >= mem_sz)
+			goto out;
+		mem_sz -= write_sz + 1;
+		mem += write_sz + 1;
+		++n;
+
+		env[n] = mem;
+		write_sz = snprintf(mem, mem_sz, "PACKETS_RCVD=%" PRIu64,
+			rx_packets);
 		if (write_sz < 0 || write_sz >= mem_sz)
 			goto out;
 		++n;

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -110,14 +110,12 @@ struct ap_session
 	int session_timeout;
 	struct triton_timer_t timer;
 
-	uint32_t acct_rx_bytes;
-	uint32_t acct_tx_bytes;
-	uint32_t acct_input_gigawords;
-	uint32_t acct_output_gigawords;
-	uint32_t acct_rx_packets_i;
-	uint32_t acct_tx_packets_i;
-	uint32_t acct_rx_bytes_i;
-	uint32_t acct_tx_bytes_i;
+	uint64_t acct_rx_bytes;
+	uint64_t acct_tx_bytes;
+	uint64_t acct_rx_packets_i;
+	uint64_t acct_tx_packets_i;
+	uint64_t acct_rx_bytes_i;
+	uint64_t acct_tx_bytes_i;
 	int acct_start;
 };
 
@@ -156,7 +154,7 @@ int ap_session_rename(struct ap_session *ses, const char *ifname, int len);
 int ap_session_vrf(struct ap_session *ses, const char *vrf_name, int len);
 #endif
 
-int ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stats *stats);
+int ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stats64 *stats);
 
 int ap_shutdown_soft(void (*cb)(void), int term);
 

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -110,6 +110,8 @@ struct ap_session
 	int session_timeout;
 	struct triton_timer_t timer;
 
+	uint64_t acct_rx_packets;
+	uint64_t acct_tx_packets;
 	uint64_t acct_rx_bytes;
 	uint64_t acct_tx_bytes;
 	uint64_t acct_rx_packets_i;

--- a/accel-pppd/libnetlink/iputils.c
+++ b/accel-pppd/libnetlink/iputils.c
@@ -103,7 +103,7 @@ out_err:
 	return -1;
 }
 
-int __export iplink_get_stats(int ifindex, struct rtnl_link_stats *stats)
+int __export iplink_get_stats(int ifindex, struct rtnl_link_stats64 *stats)
 {
 	struct iplink_req {
 		struct nlmsghdr n;
@@ -142,8 +142,8 @@ int __export iplink_get_stats(int ifindex, struct rtnl_link_stats *stats)
 		goto out;
 
 	parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
-	if (tb[IFLA_STATS]) {
-		memcpy(stats, RTA_DATA(tb[IFLA_STATS]), sizeof(*stats));
+	if (tb[IFLA_STATS64]) {
+		memcpy(stats, RTA_DATA(tb[IFLA_STATS64]), sizeof(*stats));
 		r = 0;
 	}
 

--- a/accel-pppd/libnetlink/iputils.h
+++ b/accel-pppd/libnetlink/iputils.h
@@ -8,7 +8,7 @@
 typedef int (*iplink_list_func)(int index, int flags, const char *name, int iflink, int vid, void *arg);
 
 int iplink_list(iplink_list_func func, void *arg);
-int iplink_get_stats(int ifindex, struct rtnl_link_stats *stats);
+int iplink_get_stats(int ifindex, struct rtnl_link_stats64 *stats);
 int iplink_set_mtu(int ifindex, int mtu);
 
 int iplink_vlan_add(const char *ifname, int ifindex, int vid);

--- a/accel-pppd/lua/session.c
+++ b/accel-pppd/lua/session.c
@@ -218,13 +218,12 @@ static int session_ipv6(lua_State *L)
 static int session_rx_bytes(lua_State *L)
 {
 	struct ap_session *ses = luaL_checkudata(L, 1, LUA_AP_SESSION);
-	uint64_t gword_sz = (uint64_t)UINT32_MAX + 1;
 	uint64_t bytes;
 
 	if (!ses)
 		return 0;
 
-	bytes = gword_sz*ses->acct_input_gigawords + ses->acct_rx_bytes;
+	bytes = ses->acct_rx_bytes;
 	lua_pushnumber(L, bytes);
 
 	return 1;
@@ -233,13 +232,12 @@ static int session_rx_bytes(lua_State *L)
 static int session_tx_bytes(lua_State *L)
 {
 	struct ap_session *ses = luaL_checkudata(L, 1, LUA_AP_SESSION);
-	uint64_t gword_sz = (uint64_t)UINT32_MAX + 1;
 	uint64_t bytes;
 
 	if (!ses)
 		return 0;
 
-	bytes = gword_sz*ses->acct_output_gigawords + ses->acct_tx_bytes;
+	bytes = ses->acct_tx_bytes;
 	lua_pushnumber(L, bytes);
 
 	return 1;

--- a/accel-pppd/ppp/ppp_lcp.c
+++ b/accel-pppd/ppp/ppp_lcp.c
@@ -621,7 +621,7 @@ static void send_echo_reply(struct ppp_lcp_t *lcp)
 static void send_echo_request(struct triton_timer_t *t)
 {
 	struct ppp_lcp_t *lcp = container_of(t, typeof(*lcp), echo_timer);
-	struct rtnl_link_stats stats;
+	struct rtnl_link_stats64 stats;
 	struct lcp_echo_req {
 		struct lcp_hdr_t hdr;
 		uint32_t magic;

--- a/accel-pppd/ppp/ppp_lcp.h
+++ b/accel-pppd/ppp/ppp_lcp.h
@@ -122,7 +122,7 @@ struct ppp_lcp_t
 	struct triton_timer_t echo_timer;
 	int echo_sent;
 	int magic;
-	unsigned long last_ipackets;
+	uint64_t last_ipackets;
 	time_t last_echo_ts;
 
 	struct list_head ropt_list; // last received ConfReq

--- a/accel-pppd/radius/acct.c
+++ b/accel-pppd/radius/acct.c
@@ -41,7 +41,7 @@ static int req_set_RA(struct rad_req_t *req, const char *secret)
 
 static int req_set_stat(struct rad_req_t *req, struct ap_session *ses)
 {
-	struct rtnl_link_stats stats;
+	struct rtnl_link_stats64 stats;
 	struct radius_pd_t *rpd = req->rpd;
 	struct timespec ts;
 	int ret = 0;
@@ -52,12 +52,12 @@ static int req_set_stat(struct rad_req_t *req, struct ap_session *ses)
 		clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	if (ap_session_read_stats(ses, &stats) == 0) {
-		rad_packet_change_int(req->pack, NULL, "Acct-Input-Octets", stats.rx_bytes);
-		rad_packet_change_int(req->pack, NULL, "Acct-Output-Octets", stats.tx_bytes);
-		rad_packet_change_int(req->pack, NULL, "Acct-Input-Packets", stats.rx_packets);
-		rad_packet_change_int(req->pack, NULL, "Acct-Output-Packets", stats.tx_packets);
-		rad_packet_change_int(req->pack, NULL, "Acct-Input-Gigawords", rpd->ses->acct_input_gigawords);
-		rad_packet_change_int(req->pack, NULL, "Acct-Output-Gigawords", rpd->ses->acct_output_gigawords);
+		rad_packet_change_int(req->pack, NULL, "Acct-Input-Octets", (int) (stats.rx_bytes & UINT32_MAX));
+		rad_packet_change_int(req->pack, NULL, "Acct-Output-Octets", (int) (stats.tx_bytes & UINT32_MAX));
+		rad_packet_change_int(req->pack, NULL, "Acct-Input-Packets", (int) (stats.rx_packets & UINT32_MAX));
+		rad_packet_change_int(req->pack, NULL, "Acct-Output-Packets", (int) (stats.tx_packets & UINT32_MAX));
+		rad_packet_change_int(req->pack, NULL, "Acct-Input-Gigawords", (int) (stats.rx_bytes >> (sizeof(uint32_t) * 8)));
+		rad_packet_change_int(req->pack, NULL, "Acct-Output-Gigawords", (int) (stats.tx_bytes >> (sizeof(uint32_t) * 8)));
 	} else
 		ret = -1;
 

--- a/accel-pppd/radius/acct.c
+++ b/accel-pppd/radius/acct.c
@@ -42,7 +42,6 @@ static int req_set_RA(struct rad_req_t *req, const char *secret)
 static int req_set_stat(struct rad_req_t *req, struct ap_session *ses)
 {
 	struct rtnl_link_stats64 stats;
-	struct radius_pd_t *rpd = req->rpd;
 	struct timespec ts;
 	int ret = 0;
 

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -72,7 +72,7 @@ void __export ap_session_init(struct ap_session *ses)
 
 void __export ap_session_set_ifindex(struct ap_session *ses)
 {
-	struct rtnl_link_stats stats;
+	struct rtnl_link_stats64 stats;
 
 	if (iplink_get_stats(ses->ifindex, &stats))
 		log_ppp_warn("failed to get interface statistics\n");
@@ -83,8 +83,6 @@ void __export ap_session_set_ifindex(struct ap_session *ses)
 		ses->acct_tx_bytes_i = stats.tx_bytes;
 		ses->acct_rx_bytes = 0;
 		ses->acct_tx_bytes = 0;
-		ses->acct_input_gigawords = 0;
-		ses->acct_output_gigawords = 0;
 	}
 }
 
@@ -380,9 +378,9 @@ static void generate_sessionid(struct ap_session *ses)
 	}
 }
 
-int __export ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stats *stats)
+int __export ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stats64 *stats)
 {
-	struct rtnl_link_stats lstats;
+	struct rtnl_link_stats64 lstats;
 
 	if (ses->ifindex == -1)
 		return -1;
@@ -403,12 +401,7 @@ int __export ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stat
 	if (stats->rx_bytes != ses->acct_rx_bytes)
 		ses->idle_time = _time();
 
-	if (stats->rx_bytes < ses->acct_rx_bytes)
-		ses->acct_input_gigawords++;
 	ses->acct_rx_bytes = stats->rx_bytes;
-
-	if (stats->tx_bytes < ses->acct_tx_bytes)
-		ses->acct_output_gigawords++;
 	ses->acct_tx_bytes = stats->tx_bytes;
 
 	return 0;

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -401,6 +401,8 @@ int __export ap_session_read_stats(struct ap_session *ses, struct rtnl_link_stat
 	if (stats->rx_bytes != ses->acct_rx_bytes)
 		ses->idle_time = _time();
 
+	ses->acct_rx_packets = stats->rx_packets;
+	ses->acct_tx_packets = stats->tx_packets;
 	ses->acct_rx_bytes = stats->rx_bytes;
 	ses->acct_tx_bytes = stats->tx_bytes;
 


### PR DESCRIPTION
This patch-set has two changes:

1. Use 64-bit interface statistics directly from the kernel instead of doing custom 32-bit overflow checking.
    When a link has a relatively high throughput, the 32-bit packet and byte counters could overflow multiple times between accounting runs.
    To accommodate this limitation, directly use 64-bit interface statistics.
    This also gets rid of the internal giga-word counters.

2. Add PACKETS_SENT and PACKETS_RCVD to the pppd-compat environment. 