### PR TITLE
Add interim update script for pppd_compat

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -264,6 +264,7 @@ verbose=1
 ip-up=/etc/ppp/ip-up
 ip-down=/etc/ppp/ip-down
 #ip-change=/etc/ppp/ip-change
+#interim-update=/etc/ppp/interim-update
 radattr-prefix=/var/run/radattr
 #fork-limit=16
 

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -1044,6 +1044,9 @@ Path to ip-down script which is executed when session is about to terminate.
 .BI "ip-change=" file
 Path to ip-change script which is executed for RADIUS CoA handling.
 .TP
+.BI "interim-update=" file
+Path to interim-update script which is executed for example when an IPv6 prefix is dynamically assigned to the peer.
+.TP
 .BI "radattr-prefix=" prefix
 Prefix of radattr files (for example /var/run/radattr, resulting files will be /var/run/radattr.pppX)
 .TP


### PR DESCRIPTION
When the delegated IPv6 prefix is not set by radius beforehand, the ip-up script will not be able to handle the prefix, as the DHCPv6 stuff is happening way after the ip-up script.
To allow some sort of script to handle the dynamic delegation of a prefix, add an interim-update script.
An example scenario would be the addition of some firewall rules for the prefix.

This script is called exactly the same as the ip-up script.