### PR TITLE
ipv6_dhcp: Add RFC6334 AFTR-Name option support

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -73,6 +73,10 @@ IPv4 address assigning module.
 .br
 IPv6 address assigning module.
 .TP
+.BI ipv6_dhcp
+.br
+IPv6 DHCP module.
+.TP
 .BI sigchld
 Helper module to manage child processes, required by pppd_compat
 .TP
@@ -1148,6 +1152,10 @@ Specifies which Radius attribute contains pool name.
 .TP
 .BI "vendor=" vendor
 If attribute is vendor-specific then specify vendor name in this option.
+.SH [ipv6-dhcp]
+.TP
+.BI "aftr-gw=" name
+Specifies the AFTR-Name option value to be returned on DHCPv6 replies upon request from the client.
 .SH [ipv6-pool]
 .br
 Configuration of ipv6pool module.

--- a/accel-pppd/ipv6/dhcpv6.h
+++ b/accel-pppd/ipv6/dhcpv6.h
@@ -34,7 +34,7 @@
 #define D6_OPTION_DOMAIN_LIST     24
 #define D6_OPTION_IA_PD           25
 #define D6_OPTION_IAPREFIX        26
-#define D6_OPTION_IAPREFIX        26
+#define D6_OPTION_AFTR_NAME       64
 
 #define D6_SOLICIT                 1
 #define D6_ADVERTISE               2

--- a/accel-pppd/ipv6/dhcpv6_packet.c
+++ b/accel-pppd/ipv6/dhcpv6_packet.c
@@ -31,6 +31,7 @@ static void print_status(struct dhcpv6_option *opt, void (*print)(const char *fm
 static void print_reconf(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...));
 static void print_dnssl(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...));
 static void print_ia_prefix(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...));
+static void print_aftr_gw(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...));
 
 static struct dict_option known_options[] = {
 	{ D6_OPTION_CLIENTID, "Client-ID", 1, 0, print_clientid },
@@ -56,6 +57,7 @@ static struct dict_option known_options[] = {
 	{ D6_OPTION_DOMAIN_LIST, "DNSSL", 1, 0, print_dnssl },
 	{ D6_OPTION_IA_PD, "IA-PD", 1, sizeof(struct dhcpv6_opt_ia_na), print_ia_na },
 	{ D6_OPTION_IAPREFIX, "IA-Prefix", 1, sizeof(struct dhcpv6_opt_ia_prefix), print_ia_prefix },
+	{ D6_OPTION_AFTR_NAME, "AFTR-Name", 1, 0, print_aftr_gw },
 	{ 0 }
 };
 
@@ -547,6 +549,24 @@ static void print_reconf(struct dhcpv6_option *opt, void (*print)(const char *fm
 static void print_dnssl(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...))
 {
 
+}
+
+static void print_aftr_gw(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...)) {
+	int len = ntohs(opt->hdr->len);
+	int offset = 0;
+	char domain[255];
+	uint8_t label_len;
+
+	memset(domain, 0, 255);
+	while (offset < len) {
+		label_len = opt->hdr->data[offset];
+		if (label_len == 0)
+			break;
+		memcpy(&domain[offset], &opt->hdr->data[offset + 1], label_len);
+		offset += label_len;
+		domain[offset++] = '.';
+	}
+	print(" %s", domain);
 }
 
 static void print_ia_prefix(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...))


### PR DESCRIPTION
While trying to implement a DS-Lite setup with accel-ppp as a PPPoE concentrator, I ran into the issue where my CPE would request the AFTR gateway hostname via DHCPv6 Option 64, but accel-ppp was unable to send it. 

I added an extra configuration parameter `aftr-gw` to the `ipv6-dhcp` section. 

I also added proper code to handle the option when printing out DHCPv6 packets in verbose mode. 