### PR TITLE
ci: remove Ubuntu 18.04 from CI pipelines, fix python issue for Debian12

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -87,7 +87,6 @@ jobs:
             "debian:10",
             "debian:11",
             "debian:bookworm",
-            "ubuntu:18.04",
             "ubuntu:20.04",
             "ubuntu:22.04",
           ]
@@ -105,7 +104,6 @@ jobs:
           debian:10) CPACK_TYPE=Debian10 ;;
           ubuntu:22.04) CPACK_TYPE=Ubuntu22 ; HEADERS_SUFFIX=generic ;;
           ubuntu:20.04) CPACK_TYPE=Ubuntu20 ; HEADERS_SUFFIX=generic ;;
-          ubuntu:18.04) CPACK_TYPE=Ubuntu18 ; HEADERS_SUFFIX=generic ;;
           esac;
           echo HEADERS_SUFFIX=$HEADERS_SUFFIX >> $GITHUB_ENV;
           echo DISTRO=$DISTRO >> $GITHUB_ENV;

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -114,7 +114,7 @@ jobs:
           git build-essential cmake gcc linux-headers-\`uname -r\` 
           libpcre3-dev libssl-dev liblua5.1-0-dev kmod python3-pip 
           iproute2 ppp pppoe isc-dhcp-client timelimit && 
-          sudo pip3 install pytest pytest-dependency gcovr"
+          (sudo pip3 install pytest pytest-dependency gcovr || sudo pip3 install --break-system-packages pytest pytest-dependency gcovr)"
       - name: Copy source code to target OS
         run: |
           tar -Jcf accel-ppp.tar.xz accel-ppp

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,11 +26,6 @@ jobs:
             untar: false
             format: qcow2
 
-          - distro: Ubuntu-18.04
-            image: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
-            untar: false
-            format: qcow2
-
           - distro: Debian12
             image: https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.tar.xz
             untar: true


### PR DESCRIPTION
Ubuntu 18.04 is EOL so remove it from CI
Debian12 python requires --break-system-packages  to install pip3 packages from root user