### PR TITLE
ipoe: add an option to not send option 82 to DHCP clients

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -366,6 +366,9 @@ Specifies default value for per-interface
 .B relay
 parameter.
 .TP
+.BI "send-dhcp-opt82-to-client=" 0|1
+If set to 0, do not send the DHCP relay information (Option 82) to the client (default: 1).
+.TP
 .BI "proxy-arp=" n
 Specifies default value for per-interface
 .B proxy-arp

--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -765,7 +765,8 @@ static inline int dhcpv4_packet_add_opt_u32(struct dhcpv4_packet *pack, int type
 
 int dhcpv4_send_reply(int msg_type, struct dhcpv4_serv *serv, struct dhcpv4_packet *req,
 	uint32_t yiaddr, uint32_t siaddr, uint32_t router, uint32_t mask,
-	int lease_time, int renew_time, int rebind_time, struct dhcpv4_packet *relay)
+	int lease_time, int renew_time, int rebind_time, struct dhcpv4_packet *relay,
+	bool opt_send_dhcp_opt82_to_client)
 {
 	struct dhcpv4_packet *pack;
 	struct dhcpv4_option *opt;
@@ -845,7 +846,9 @@ int dhcpv4_send_reply(int msg_type, struct dhcpv4_serv *serv, struct dhcpv4_pack
 			goto out_err;
 	}
 
-	if (req->relay_agent && dhcpv4_packet_add_opt(pack, 82, req->relay_agent->data, req->relay_agent->len))
+	if (opt_send_dhcp_opt82_to_client
+			&& req->relay_agent
+			&& dhcpv4_packet_add_opt(pack, 82, req->relay_agent->data, req->relay_agent->len))
 		goto out_err;
 
 	*pack->ptr++ = 255;
@@ -872,7 +875,8 @@ out_err:
 	return -1;
 }
 
-int dhcpv4_send_nak(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, const char *err)
+int dhcpv4_send_nak(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, const char *err,
+		bool opt_send_dhcp_opt82_to_client)
 {
 	struct dhcpv4_packet *pack;
 	int val, r;
@@ -899,7 +903,9 @@ int dhcpv4_send_nak(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, const c
 	if (server_id && dhcpv4_packet_add_opt(pack, 54, &server_id, 4))
 		goto out_err;
 
-	if (req->relay_agent && dhcpv4_packet_add_opt(pack, 82, req->relay_agent->data, req->relay_agent->len))
+	if (opt_send_dhcp_opt82_to_client
+			&& req->relay_agent
+			&& dhcpv4_packet_add_opt(pack, 82, req->relay_agent->data, req->relay_agent->len))
 		goto out_err;
 
 	if (err && dhcpv4_packet_add_opt(pack, 56, err, strlen(err)))

--- a/accel-pppd/ctrl/ipoe/dhcpv4.h
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <endian.h>
+#include <stdbool.h>
 #include "list.h"
 
 #include "triton.h"
@@ -122,8 +123,10 @@ int dhcpv4_relay_send_release(struct dhcpv4_relay *relay, uint8_t *chaddr, uint3
         const char *link_selection);
 int dhcpv4_send_reply(int msg_type, struct dhcpv4_serv *serv, struct dhcpv4_packet *req,
 	uint32_t yiaddr, uint32_t siaddr, uint32_t router, uint32_t mask,
-	int lease_time, int renew_time, int rebind_time, struct dhcpv4_packet *relay_reply);
-int dhcpv4_send_nak(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, const char *err);
+	int lease_time, int renew_time, int rebind_time, struct dhcpv4_packet *relay_reply,
+	bool opt_send_dhcp_opt82_to_client);
+int dhcpv4_send_nak(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, const char *err,
+		bool opt_send_dhcp_opt82_to_client);
 
 void dhcpv4_send_notify(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, unsigned int weight);
 

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -70,6 +70,7 @@ struct ipoe_serv {
 	unsigned int need_close:1;
 	unsigned int active:1;
 	unsigned int vlan_mon:1;
+	unsigned int opt_send_dhcp_opt82_to_client:1;
 };
 
 struct ipoe_session {


### PR DESCRIPTION
DHCP option 82 fields carry the DHCP relay agent information to the DHCP
servers. Option 82 fields do not normally need to be disclosed to the
DHCP clients.

Add an option to not send DHCP option 82 fields to clients. By default,
the fields are sent to not change the current behavior.