### PR TITLE
ipoe: fix memory access violation with unset link-selection

### DIFF
--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -4006,6 +4006,8 @@ static void load_config(void)
 	opt = conf_get_opt("ipoe", "link-selection");
 	if (opt && inet_pton(AF_INET, opt, &dummy) > 0)
 		conf_link_selection = opt;
+	else
+		conf_link_selection = NULL;
 
 	opt = conf_get_opt("ipoe", "ipv6");
 	if (opt)


### PR DESCRIPTION
Link-selection pointer is not set to NULL when link-selection IPOE option is not set. It results in a memory access violation in dhcpv4_packet_insert_opt82()

Set link-selection pointer to NULL if unset to fix the issue.

Fixes: 61e31c591e ("ipoe: add dhcp link selection sub-option")