### PR TITLE
Add support for Debian 13

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -86,7 +86,8 @@ jobs:
           [
             "debian:10",
             "debian:11",
-            "debian:bookworm",
+            "debian:12",
+            "debian:trixie",
             "ubuntu:20.04",
             "ubuntu:22.04",
           ]
@@ -99,7 +100,8 @@ jobs:
           HEADERS_SUFFIX=`uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/`;
           DISTRO=`echo ${{ matrix.distro }} |  sed 's/://'`;
           case "${{ matrix.distro }}" in
-          debian:bookworm) DISTRO=debian12; CPACK_TYPE=Debian12 ;;
+          debian:trixie) DISTRO=debian13; CPACK_TYPE=Debian13 ;;
+          debian:12) DISTRO=debian12; CPACK_TYPE=Debian12 ;;
           debian:11) CPACK_TYPE=Debian11 ;;
           debian:10) CPACK_TYPE=Debian10 ;;
           ubuntu:22.04) CPACK_TYPE=Ubuntu22 ; HEADERS_SUFFIX=generic ;;

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,8 +26,13 @@ jobs:
             untar: false
             format: qcow2
 
+          - distro: Debian13
+            image: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-generic-amd64-daily.tar.xz
+            untar: true
+            format: raw
+
           - distro: Debian12
-            image: https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.tar.xz
+            image: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.tar.xz
             untar: true
             format: raw
 

--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -60,6 +60,11 @@ IF(CPACK_TYPE STREQUAL Debian12)
 	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
 ENDIF(CPACK_TYPE STREQUAL Debian12)
 
+IF(CPACK_TYPE STREQUAL Debian13)
+	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.37), libssl3 (>= 3.0.9), libpcre3 (>= 8.39)")
+	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
+ENDIF(CPACK_TYPE STREQUAL Debian13)
+
 IF(CPACK_TYPE STREQUAL Ubuntu16)
 	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.23), libssl1.0.0 (>= 1.0.0), libpcre3 (>= 8.39)")
 	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)


### PR DESCRIPTION
Build and tests will work on Debian13 after applying this fix for ipoe module for linux 6.3: https://github.com/accel-ppp/accel-ppp/pull/98 (tested here https://github.com/svlobanov/accel-ppp/actions/runs/5579884481/jobs/10196033988)