### PR TITLE
ipoe: add an option to set router DHCP option 3

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -366,6 +366,11 @@ Specifies default value for per-interface
 .B relay
 parameter.
 .TP
+.BI "router=" ipv4_address
+Specifies default value for per-interface
+.B router
+parameter.
+.TP
 .BI "proxy-arp=" n
 Specifies default value for per-interface
 .B proxy-arp
@@ -406,6 +411,7 @@ option nor this option is present, option 82 is not inserted by the DCHP Relay A
 .BI "" [,relay=x.x.x.x]
 .BI "" [,giaddr=x.x.x.x]
 .BI "" [,src=x.x.x.x]
+.BI "" [,router=x.x.x.x]
 .BI "" [,proxy-arp=0|1|2]
 .BI "" [,username=ifname|lua:function]
 .BI "" [,ipv6=0|1]
@@ -464,6 +470,10 @@ parameter specifies relay agent IP address.
 The
 .B src
 parameter specifies ip address to use as source when adding route to client.
+.br
+The
+.B router
+parameter specifies the router ip address (option 3) to set if not already set by the server.
 .br
 The
 .B proxy-arp

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -371,6 +371,11 @@ Specifies default value for per-interface
 .B router
 parameter.
 .TP
+.BI "router-force=" 0|1
+Specifies default value for per-interface
+.B router-force
+parameter.
+.TP
 .BI "proxy-arp=" n
 Specifies default value for per-interface
 .B proxy-arp
@@ -412,6 +417,7 @@ option nor this option is present, option 82 is not inserted by the DCHP Relay A
 .BI "" [,giaddr=x.x.x.x]
 .BI "" [,src=x.x.x.x]
 .BI "" [,router=x.x.x.x]
+.BI "" [,router-force=0|1]
 .BI "" [,proxy-arp=0|1|2]
 .BI "" [,username=ifname|lua:function]
 .BI "" [,ipv6=0|1]
@@ -473,7 +479,11 @@ parameter specifies ip address to use as source when adding route to client.
 .br
 The
 .B router
-parameter specifies the router ip address (option 3) to set if not already set by the server.
+parameter specifies the router ip address (option 3) to set.
+.br
+If the
+.B router-force
+parameter is set, the DHCP option 3 from the server is replaced by the configured value.
 .br
 The
 .B proxy-arp

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -2033,7 +2033,7 @@ static void ipoe_ses_recv_dhcpv4_relay(struct dhcpv4_packet *pack)
 		ses->mask = parse_dhcpv4_mask(ntohl(*(uint32_t *)opt->data));
 
 	opt = dhcpv4_packet_find_opt(pack, 3);
-	if (opt)
+	if (opt && !ses->serv->opt_router_force)
 		ses->router = *(uint32_t *)opt->data;
 
 	if (pack->msg_type == DHCPOFFER) {
@@ -2379,6 +2379,8 @@ static void ev_radius_access_accept(struct ev_radius_t *ev)
 					ses->siaddr = attr->val.ipaddr;
 					break;
 				case DHCP_Router_Address:
+					if (ses->serv->opt_router_force)
+						break;
 					ses->router = *(in_addr_t *)attr->raw;
 					break;
 				case DHCP_Subnet_Mask:
@@ -2409,7 +2411,7 @@ static void ev_radius_access_accept(struct ev_radius_t *ev)
 
 		if (attr->attr->id == conf_attr_dhcp_client_ip)
 			ses->yiaddr = attr->val.ipaddr;
-		else if (attr->attr->id == conf_attr_dhcp_router_ip)
+		else if (attr->attr->id == conf_attr_dhcp_router_ip && !ses->serv->opt_router_force)
 			ses->router = attr->val.ipaddr;
 		else if (attr->attr->id == conf_attr_dhcp_mask) {
 			if (attr->attr->type == ATTR_TYPE_INTEGER) {

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -865,6 +865,9 @@ static void __ipoe_session_start(struct ipoe_session *ses)
 		}
 	}
 
+	if (!ses->router && ses->serv->opt_router)
+		ses->router = ses->serv->opt_router;
+
 	if (ses->ses.ipv4) {
 		if (!ses->mask)
 			ses->mask = ses->ses.ipv4->mask;

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -123,6 +123,7 @@ static int conf_arp;
 static int conf_ipv6;
 static uint32_t conf_src;
 static uint32_t conf_router;
+static int conf_router_force;
 static const char *conf_ip_pool;
 static const char *conf_ipv6_pool;
 static const char *conf_dpv6_pool;
@@ -2998,6 +2999,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	in_addr_t opt_giaddr = 0;
 	in_addr_t opt_src = conf_src;
 	in_addr_t opt_router = conf_router;
+	int opt_router_force = conf_router_force;
 	int opt_arp = conf_arp;
 	struct ifreq ifr;
 	uint8_t hwaddr[ETH_ALEN];
@@ -3056,6 +3058,8 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 				opt_src = inet_addr(ptr1);
 			} else if (strcmp(str, "router") == 0) {
 				opt_router = inet_addr(ptr1);
+			} else if (strcmp(str, "router-force") == 0) {
+				opt_router_force = atoi(ptr1);
 			} else if (strcmp(str, "proxy-arp") == 0) {
 				opt_arp = atoi(ptr1);
 			} else if (strcmp(str, "ipv6") == 0) {
@@ -3169,6 +3173,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 		serv->opt_nat = opt_nat;
 		serv->opt_src = opt_src;
 		serv->opt_router = opt_router;
+		serv->opt_router_force = !!(opt_router && opt_router_force);
 		serv->opt_arp = opt_arp;
 		serv->opt_username = opt_username;
 		serv->opt_ipv6 = opt_ipv6;
@@ -3256,6 +3261,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	serv->opt_nat = opt_nat;
 	serv->opt_src = opt_src;
 	serv->opt_router = opt_router;
+	serv->opt_router_force = !!(opt_router && opt_router_force);
 	serv->opt_arp = opt_arp;
 	serv->opt_username = opt_username;
 	serv->opt_ipv6 = opt_ipv6;
@@ -3975,6 +3981,12 @@ static void load_config(void)
 		conf_router = inet_addr(opt);
 	else
 		conf_router = 0;
+
+	opt = conf_get_opt("ipoe", "router-force");
+	if (opt)
+		conf_router_force = atoi(opt);
+	else
+		conf_router_force = 1;
 
 	opt = conf_get_opt("ipoe", "proxy-arp");
 	if (opt)

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -122,6 +122,7 @@ static int conf_nat;
 static int conf_arp;
 static int conf_ipv6;
 static uint32_t conf_src;
+static uint32_t conf_router;
 static const char *conf_ip_pool;
 static const char *conf_ipv6_pool;
 static const char *conf_dpv6_pool;
@@ -2993,6 +2994,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	in_addr_t relay_addr = conf_relay ? inet_addr(conf_relay) : 0;
 	in_addr_t opt_giaddr = 0;
 	in_addr_t opt_src = conf_src;
+	in_addr_t opt_router = conf_router;
 	int opt_arp = conf_arp;
 	struct ifreq ifr;
 	uint8_t hwaddr[ETH_ALEN];
@@ -3049,6 +3051,8 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 				opt_nat = atoi(ptr1);
 			} else if (strcmp(str, "src") == 0) {
 				opt_src = inet_addr(ptr1);
+			} else if (strcmp(str, "router") == 0) {
+				opt_router = inet_addr(ptr1);
 			} else if (strcmp(str, "proxy-arp") == 0) {
 				opt_arp = atoi(ptr1);
 			} else if (strcmp(str, "ipv6") == 0) {
@@ -3161,6 +3165,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 		serv->opt_ifcfg = opt_ifcfg;
 		serv->opt_nat = opt_nat;
 		serv->opt_src = opt_src;
+		serv->opt_router = opt_router;
 		serv->opt_arp = opt_arp;
 		serv->opt_username = opt_username;
 		serv->opt_ipv6 = opt_ipv6;
@@ -3247,6 +3252,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	serv->opt_ifcfg = opt_ifcfg;
 	serv->opt_nat = opt_nat;
 	serv->opt_src = opt_src;
+	serv->opt_router = opt_router;
 	serv->opt_arp = opt_arp;
 	serv->opt_username = opt_username;
 	serv->opt_ipv6 = opt_ipv6;
@@ -3960,6 +3966,12 @@ static void load_config(void)
 		conf_src = inet_addr(opt);
 	else
 		conf_src = 0;
+
+	opt = conf_get_opt("ipoe", "router");
+	if (opt)
+		conf_router = inet_addr(opt);
+	else
+		conf_router = 0;
 
 	opt = conf_get_opt("ipoe", "proxy-arp");
 	if (opt)

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -52,6 +52,7 @@ struct ipoe_serv {
 	int parent_vid;
 	int opt_mode;
 	uint32_t opt_src;
+	uint32_t opt_router;
 	int opt_arp;
 	int opt_username;
 	int opt_mtu;

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -67,6 +67,7 @@ struct ipoe_serv {
 	unsigned int opt_ifcfg:1;
 	unsigned int opt_nat:1;
 	unsigned int opt_ipv6:1;
+	unsigned int opt_router_force:1;
 	unsigned int opt_ip_unnumbered:1;
 	unsigned int need_close:1;
 	unsigned int active:1;


### PR DESCRIPTION
The DHCP server does not always know the router interface IP addresses. It is sometimes more convenient that the DHCP relay on router sets itself the gateway with the DHCPOFFER / DHCPACK.

Add an option to set router DHCP option 3 if not present in the incoming DHCPOFFER / DHCPACK. And a "force" option to reset the router DHCP option 3 to the configured value.