### PR TITLE
ipoe: add a config option to reset the subnet-mask DHCP option 1

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -475,7 +475,9 @@ is set to 1, accel-ppp will always assign /32 mask. Default value is 1.
 .br
 The
 .B netmask
-parameter specifies the netmask integer value from 1 to 32 to set when the subnet-mask DHCP option 1 is not sent by the server.
+parameter specifies the netmask integer value from 1 to 32 to set when the subnet-mask DHCP option 1 is not sent by the server. If
+.B ip-unnumbered
+is set, the netmask will always be 32 regardless of this value.
 .br
 The
 .B proxy-arp

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -374,6 +374,12 @@ parameter.
 .BI "weight=" n
 Specifies global weight of this server (used for load balancing)
 .TP
+.BI "netmask=" n
+Specifies default value for per-interface
+.B netmask
+parameter.
+.br
+.TP
 .BI "ip-unnumbered=" 0|1
 Specifies default value for per-interface
 .B ip-unnumbered
@@ -409,6 +415,7 @@ option nor this option is present, option 82 is not inserted by the DCHP Relay A
 .BI "" [,mtu=N]
 .BI "" [,weight=N]
 .BI "" [,ip-unnumbered=0|1]
+.BI "" [,netmask=N]
 .br
 Specifies interface to listen dhcp or unclassified packets. You may specify multiple
 .B interface
@@ -465,6 +472,10 @@ parameter specifies ip address to use as source when adding route to client.
 If the
 .B ip-unnumbered
 is set to 1, accel-ppp will always assign /32 mask. Default value is 1.
+.br
+The
+.B netmask
+parameter specifies the netmask integer value from 1 to 32 to set when the subnet-mask DHCP option 1 is not sent by the server.
 .br
 The
 .B proxy-arp

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -386,6 +386,12 @@ Specifies default value for per-interface
 parameter.
 .br
 .TP
+.BI "netmask-force=" 0|1
+Specifies default value for per-interface
+.B netmask-force
+parameter.
+.br
+.TP
 .BI "agent-remote-id=" string
 Specifies the DCHP option 82 sub-option 2 to be inserted by the DHCP Relay.
 .br
@@ -415,6 +421,7 @@ option nor this option is present, option 82 is not inserted by the DCHP Relay A
 .BI "" [,mtu=N]
 .BI "" [,weight=N]
 .BI "" [,ip-unnumbered=0|1]
+.BI "" [,netmask-force=0|1]
 .BI "" [,netmask=N]
 .br
 Specifies interface to listen dhcp or unclassified packets. You may specify multiple
@@ -478,6 +485,14 @@ The
 parameter specifies the netmask integer value from 1 to 32 to set when the subnet-mask DHCP option 1 is not sent by the server. If
 .B ip-unnumbered
 is set, the netmask will always be 32 regardless of this value.
+.br
+If the
+.B netmask-force
+is set, accel-ppp will replace the subnet-mask (option 1) value sent by the DHCP server to 255.255.255.255 if
+.B ip-unnumbered
+if set or by the
+.B netmask
+value. Default netmask-force value is 0.
 .br
 The
 .B proxy-arp

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -379,9 +379,6 @@ Specifies default value for per-interface
 .B ip-unnumbered
 parameter.
 .br
-If ip-unnumbered=1 accel-ppp will always assign /32 mask.
-.br
-Default value is 1.
 .TP
 .BI "agent-remote-id=" string
 Specifies the DCHP option 82 sub-option 2 to be inserted by the DHCP Relay.
@@ -464,6 +461,10 @@ parameter specifies relay agent IP address.
 The
 .B src
 parameter specifies ip address to use as source when adding route to client.
+.br
+If the
+.B ip-unnumbered
+is set to 1, accel-ppp will always assign /32 mask. Default value is 1.
 .br
 The
 .B proxy-arp

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -892,7 +892,7 @@ static void __ipoe_session_start(struct ipoe_session *ses)
 			find_gw_addr(ses);
 
 		if (!ses->mask)
-			ses->mask = conf_netmask;
+			ses->mask = ses->serv->opt_netmask;
 
 		if (!ses->mask)
 			ses->mask = 32;
@@ -2993,6 +2993,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	in_addr_t relay_addr = conf_relay ? inet_addr(conf_relay) : 0;
 	in_addr_t opt_giaddr = 0;
 	in_addr_t opt_src = conf_src;
+	uint8_t opt_netmask = conf_netmask, opt_netmask_tmp;
 	int opt_arp = conf_arp;
 	struct ifreq ifr;
 	uint8_t hwaddr[ETH_ALEN];
@@ -3049,6 +3050,10 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 				opt_nat = atoi(ptr1);
 			} else if (strcmp(str, "src") == 0) {
 				opt_src = inet_addr(ptr1);
+			} else if (strcmp(str, "netmask") == 0) {
+				opt_netmask_tmp = atoi(ptr1);
+				if (opt_netmask_tmp > 0 && opt_netmask_tmp <= 32)
+					opt_netmask = opt_netmask_tmp;
 			} else if (strcmp(str, "proxy-arp") == 0) {
 				opt_arp = atoi(ptr1);
 			} else if (strcmp(str, "ipv6") == 0) {
@@ -3166,6 +3171,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 		serv->opt_ipv6 = opt_ipv6;
 		serv->opt_weight = opt_weight;
 		serv->opt_ip_unnumbered = opt_ip_unnumbered;
+		serv->opt_netmask = opt_netmask;
 #ifdef USE_LUA
 		if (serv->opt_lua_username_func && (!opt_lua_username_func || strcmp(serv->opt_lua_username_func, opt_lua_username_func))) {
 			_free(serv->opt_lua_username_func);
@@ -3253,6 +3259,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	serv->opt_mtu = opt_mtu;
 	serv->opt_weight = opt_weight;
 	serv->opt_ip_unnumbered = opt_ip_unnumbered;
+	serv->opt_netmask = opt_netmask;
 #ifdef USE_LUA
 	serv->opt_lua_username_func = opt_lua_username_func;
 #endif

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -178,6 +178,7 @@ static int conf_proto;
 static LIST_HEAD(conf_offer_delay);
 static const char *conf_vlan_name;
 static int conf_ip_unnumbered;
+static int conf_netmask_force;
 static int conf_check_mac_change;
 static int conf_soft_terminate;
 static int conf_calling_sid = SID_MAC;
@@ -2986,6 +2987,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	int opt_mtu = 0;
 	int opt_weight = -1;
 	int opt_ip_unnumbered = conf_ip_unnumbered;
+	int opt_netmask_force = conf_netmask_force;
 #ifdef USE_LUA
 	char *opt_lua_username_func = NULL;
 #endif
@@ -3063,6 +3065,8 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 			} else if (strcmp(str, "weight") == 0) {
 				opt_weight = atoi(ptr1);
 			} else if (strcmp(str, "ip-unnumbered") == 0) {
+				opt_ip_unnumbered = atoi(ptr1);
+			} else if (strcmp(str, "netmask-force") == 0) {
 				opt_ip_unnumbered = atoi(ptr1);
 			} else if (strcmp(str, "username") == 0) {
 				if (strcmp(ptr1, "ifname") == 0)
@@ -3172,6 +3176,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 		serv->opt_weight = opt_weight;
 		serv->opt_ip_unnumbered = opt_ip_unnumbered;
 		serv->opt_netmask = opt_ip_unnumbered ? 32 : opt_netmask;
+		serv->opt_netmask_force = !!(serv->opt_netmask && opt_netmask_force);
 #ifdef USE_LUA
 		if (serv->opt_lua_username_func && (!opt_lua_username_func || strcmp(serv->opt_lua_username_func, opt_lua_username_func))) {
 			_free(serv->opt_lua_username_func);
@@ -3260,6 +3265,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	serv->opt_weight = opt_weight;
 	serv->opt_ip_unnumbered = opt_ip_unnumbered;
 	serv->opt_netmask = opt_ip_unnumbered ? 32 : opt_netmask;
+	serv->opt_netmask_force = !!(serv->opt_netmask && opt_netmask_force);
 #ifdef USE_LUA
 	serv->opt_lua_username_func = opt_lua_username_func;
 #endif
@@ -4081,6 +4087,12 @@ static void load_config(void)
 		conf_ip_unnumbered = atoi(opt);
 	else
 		conf_ip_unnumbered = 1;
+
+	opt = conf_get_opt("ipoe", "netmask-force");
+	if (opt)
+		conf_netmask_force = atoi(opt);
+	else
+		conf_netmask_force = 1;
 
 	opt = conf_get_opt("ipoe", "idle-timeout");
 	if (opt)

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -166,7 +166,7 @@ static int conf_offer_timeout = 10;
 static int conf_relay_timeout = 3;
 static int conf_relay_retransmit = 3;
 static LIST_HEAD(conf_gw_addr);
-static int conf_netmask = 24;
+static int conf_netmask;
 static int conf_lease_time = LEASE_TIME;
 static int conf_lease_timeout = LEASE_TIME + LEASE_TIME/10;
 static int conf_renew_time = LEASE_TIME/2;

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -3171,7 +3171,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 		serv->opt_ipv6 = opt_ipv6;
 		serv->opt_weight = opt_weight;
 		serv->opt_ip_unnumbered = opt_ip_unnumbered;
-		serv->opt_netmask = opt_netmask;
+		serv->opt_netmask = opt_ip_unnumbered ? 32 : opt_netmask;
 #ifdef USE_LUA
 		if (serv->opt_lua_username_func && (!opt_lua_username_func || strcmp(serv->opt_lua_username_func, opt_lua_username_func))) {
 			_free(serv->opt_lua_username_func);
@@ -3259,7 +3259,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 	serv->opt_mtu = opt_mtu;
 	serv->opt_weight = opt_weight;
 	serv->opt_ip_unnumbered = opt_ip_unnumbered;
-	serv->opt_netmask = opt_netmask;
+	serv->opt_netmask = opt_ip_unnumbered ? 32 : opt_netmask;
 #ifdef USE_LUA
 	serv->opt_lua_username_func = opt_lua_username_func;
 #endif

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -52,6 +52,7 @@ struct ipoe_serv {
 	int parent_vid;
 	int opt_mode;
 	uint32_t opt_src;
+	uint8_t opt_netmask;
 	int opt_arp;
 	int opt_username;
 	int opt_mtu;

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -68,6 +68,7 @@ struct ipoe_serv {
 	unsigned int opt_nat:1;
 	unsigned int opt_ipv6:1;
 	unsigned int opt_ip_unnumbered:1;
+	unsigned int opt_netmask_force:1;
 	unsigned int need_close:1;
 	unsigned int active:1;
 	unsigned int vlan_mon:1;


### PR DESCRIPTION
Some DHCP server like KEA DHCP server does not allow setting a /32 mask.
See the DHCP option 1 on the latest documentation https://kea.readthedocs.io/en/kea-2.5.0/arm/dhcp4-srv.html#id3 It says that it is "calculated automatically, based on subnet definition.".

In the KEA config, you define a subnet and some pools. The mask is taken from the subnet only.
```
    "subnet4": [
      {
        "subnet": "10.0.0.0/8",
        "pools": [
          {
            "pool": "10.16.0.1 - 10.31.0.254"
          }
        ],
```

Add an option to reset subnet-mask DHCP option 1. Also, rework and document the netmask and ip-unnumbered configuration option.
