### PR TITLE
ipoe: fix echoing back dhcp option 82

### DIFF
--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -1085,45 +1085,53 @@ void dhcpv4_relay_free(struct dhcpv4_relay *r, struct triton_context_t *ctx)
 
 int dhcpv4_relay_send(struct dhcpv4_relay *relay, struct dhcpv4_packet *request, uint32_t server_id, const char *agent_circuit_id, const char *agent_remote_id, const char *link_selection)
 {
-	int n;
-	int len = request->ptr - request->data;
-	uint32_t giaddr = request->hdr->giaddr;
-	struct dhcpv4_option *opt = NULL;
-	uint32_t _server_id;
+	int len, n;
+	struct dhcpv4_option *opt;
+	struct dhcpv4_packet *pack;
+	uint8_t *data;
 
-	if (!request->relay_agent && (agent_remote_id || link_selection) &&
-	    dhcpv4_packet_insert_opt82(request, agent_circuit_id, agent_remote_id, link_selection))
-		return -1;
-
-	request->hdr->giaddr = relay->giaddr;
-
-	if (server_id) {
-		opt = dhcpv4_packet_find_opt(request, 54);
-		if (opt) {
-			_server_id = *(uint32_t *)opt->data;
-			*(uint32_t *)opt->data = server_id;
+	/* Build a relay packet from the client request */
+	pack = dhcpv4_packet_alloc();
+	memcpy(pack->hdr, request->hdr, sizeof(struct dhcpv4_hdr));
+	pack->hdr->giaddr = relay->giaddr;
+	pack->msg_type = request->msg_type;
+	list_for_each_entry(opt, &request->options, entry) {
+		if (opt->type == 54 && server_id)
+			/* filter out "Server ID" option 54 from client */
+			data = (void *) &server_id;
+		else
+			data = opt->data;
+		/* copy client option */
+		if (dhcpv4_packet_add_opt(pack, opt->type, data, opt->len) < 0) {
+			dhcpv4_packet_free(pack);
+			return -1;
 		}
 	}
 
-	len = request->ptr - request->data;
+	/* add padding */
+	*pack->ptr++ = 255;
+
+	/* Insert "Agent information" option 82 if not already set */
+	if (!request->relay_agent && (agent_remote_id || link_selection) &&
+	    dhcpv4_packet_insert_opt82(pack, agent_circuit_id, agent_remote_id, link_selection))
+		return -1;
+
+	len = pack->ptr - pack->data;
 
 	// pad packet to minimal bootp length
 	if (len < 300) {
-		memset(request->ptr, 0, 300 - len);
+		memset(pack->ptr, 0, 300 - len);
 		len = 300;
 	}
 
 	if (conf_verbose) {
 		log_ppp_info2("send ");
-		dhcpv4_print_packet(request, 1, log_ppp_info2);
+		dhcpv4_print_packet(pack, 1, log_ppp_info2);
 	}
 
-	n = write(relay->hnd.fd, request->data, len);
+	n = write(relay->hnd.fd, pack->data, len);
 
-	request->hdr->giaddr = giaddr;
-
-	if (opt)
-		*(uint32_t *)opt->data = _server_id;
+	dhcpv4_packet_free(pack);
 
 	if (n != len)
 		return -1;


### PR DESCRIPTION
RFC3046 says:

> The Relay Agent Information option [82] echoed by a server MUST be removed
> by either the relay agent or the trusted downstream network element
> which added it when forwarding a server-to-client response back to
> the client.

985cb9f994 ("ipoe: dhcpv4: echo back opt82 if sent by client/unknown relay per rfc3046") was supposed to implement this requirement. However, it does not work because dhcpv4_relay_send() modifies the original incoming request before relaying it.

Fix the requirement conformity by working on a copy of the original request in dhcpv4_relay_send().

Tested with the dhtest tool with and without an option 82:

> ./dhtest -i ens3
> ./dhtest -c 82,hex,010876786c312e31313102104147454e542d52454d4f54452d49443105040a0f4002 -i ens3

Fixes: 985cb9f994 ("ipoe: dhcpv4: echo back opt82 if sent by client/unknown relay per rfc3046")
Link: https://www.rfc-editor.org/rfc/rfc3046.html#section-2.1
Link: https://github.com/saravana815/dhtest