### PR TITLE
[ipoe.c] arp-reply not send with ip_unnumbering is enabled.

### DIFF
--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -964,7 +964,7 @@ static void __ipoe_session_start(struct ipoe_session *ses)
 
 		ses->siaddr = ses->router;
 
-		if (ses->arph) {
+		if (ses->arph && !ses->serv->opt_ip_unnumbered) {
 			if (ses->serv->opt_shared)
 				ses->wait_start = 1;
 


### PR DESCRIPTION
```
    100.64.0.1.67 > 11.116.22.130.68: BOOTP/DHCP, Reply, length 310, xid 0xfa31fff8, Flags [none]
	  Your-IP 11.116.22.130
	  Client-Ethernet-Address 50:0f:f5:a3:ed:f8
	  Vendor-rfc1048 Extensions
	    Magic Cookie 0x63825363
	    DHCP-Message (53), length 1: ACK
	    Server-ID (54), length 4: 100.64.0.1
	    Lease-Time (51), length 4: 600
	    RN (58), length 4: 300
	    RB (59), length 4: 525
	    Default-Gateway (3), length 4: 100.64.0.1
	    Subnet-Mask (1), length 4: 255.255.255.255
	    Domain-Name-Server (6), length 8: 8.8.8.8,8.8.4.4
	    Agent-Information (82), length 18: 
	      Circuit-ID SubOption 1, length 6: ^@^D^@i^@^E
	      Remote-ID SubOption 2, length 8: ^@^FM-HM->^YM-tUM-0
16:52:22.205319 50:0f:f5:a3:ed:f8 > ff:ff:ff:ff:ff:ff, ethertype 802.1Q (0x8100), length 64: vlan 105, p 0, ethertype ARP (0x0806), Ethernet (len 6), IPv4 (len 4), Request who-has 11.116.22.130 tell 91.216.22.130, length 46
16:52:22.210347 50:0f:f5:a3:ed:f8 > ff:ff:ff:ff:ff:ff, ethertype 802.1Q (0x8100), length 64: vlan 105, p 0, ethertype ARP (0x0806), Ethernet (len 6), IPv4 (len 4), Request who-has 11.116.22.130 tell 0.0.0.0, length 46
16:52:22.216972 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 114: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 1, next-header Options (0) payload length: 56) :: > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 2 group record(s) [gaddr ff02::1:ff2f:a115 to_ex, 0 source(s)] [gaddr ff02::2 to_ex, 0 source(s)]
16:52:22.736967 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 90: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 255, next-header ICMPv6 (58) payload length: 32) :: > ff02::1:ff2f:a115: [icmp6 sum ok] ICMP6, neighbor solicitation, length 32, who has fe80::2e0:edff:fe2f:a115
	  unknown option (14), length 8 (1): 
	  0x0000:  dbb0 ebc3 1609
16:52:23.024965 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 114: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 1, next-header Options (0) payload length: 56) :: > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 2 group record(s) [gaddr ff02::1:ff2f:a115 to_ex, 0 source(s)] [gaddr ff02::2 to_ex, 0 source(s)]
16:52:23.760972 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 134: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 1, next-header Options (0) payload length: 76) fe80::2e0:edff:fe2f:a115 > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 3 group record(s) [gaddr ff02::1:ff00:0 to_ex, 0 source(s)] [gaddr ff02::1:ff2f:a115 to_ex, 0 source(s)] [gaddr ff02::2 to_ex, 0 source(s)]
16:52:23.772965 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 94: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 1, next-header Options (0) payload length: 36) fe80::2e0:edff:fe2f:a115 > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 1 group record(s) [gaddr ff02::1:ff00:0 to_ex, 0 source(s)]
16:52:24.080964 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 94: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 1, next-header Options (0) payload length: 36) fe80::2e0:edff:fe2f:a115 > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 1 group record(s) [gaddr ff02::1:ff00:0 to_ex, 0 source(s)]
16:52:24.236964 00:e0:ed:2f:a1:15 > 50:0f:f5:a3:ed:f8, ethertype 802.1Q (0x8100), length 134: vlan 105, p 0, ethertype IPv6 (0x86dd), (hlim 1, next-header Options (0) payload length: 76) fe80::2e0:edff:fe2f:a115 > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 3 group record(s) [gaddr ff02::1:ff00:0 to_ex, 0 source(s)] [gaddr ff02::1:ff2f:a115 to_ex, 0 source(s)] [gaddr ff02::2 to_ex, 0 source(s)]
```
And yes, Some routers send arp after configuration interface as unnumbering. In this situation accel  not response to client on arp  request.