### PR TITLE
ci: build for mainline kernel, use explicit name for debian13 instead of sid

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -165,3 +165,51 @@ jobs:
           name: deb-package-${{ env.DISTRO }}-${{ env.UNAME_M }}-${{ env.KERNEL_NAME }}
           path: build/accel-ppp_*.deb
           if-no-files-found: error
+
+  Build-in-Container-Mainline:
+    #if: ${{ false }} # disable for now
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:devel
+    steps:
+      - name: Install build tools
+        run: >
+          apt update && apt -y upgrade && apt -y dist-upgrade &&
+          DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt -y install git build-essential cmake gcc
+          linux-headers-generic libpcre3-dev libssl-dev liblua5.1-0-dev kmod software-properties-common
+          pkexec dbus linux-base &&
+          add-apt-repository -y ppa:cappelikan/ppa && apt update &&
+          service dbus start &&
+          apt -y install mainline &&
+          mainline --include-rc install-latest &&
+          apt -y purge linux-headers-generic && apt -y autoremove
+      - name: Get kernel name from headers
+        run: >
+          echo KERNEL_NAME=`ls -1 /usr/src/ | grep  'linux-headers.*generic' |
+          sed 's/linux-headers-//'` >> $GITHUB_ENV;
+          cat $GITHUB_ENV
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: mkdir build
+        run: mkdir build
+      - name: Disable git security warnings
+        run: git config --global --add safe.directory '*'
+      - name: cmake
+        working-directory: ./build
+        run: >
+          cmake -DBUILD_IPOE_DRIVER=TRUE -DBUILD_VLAN_MON_DRIVER=TRUE -DCMAKE_INSTALL_PREFIX=/usr
+          -DCMAKE_INSTALL_SYSCONFDIR=/etc
+          -DKDIR=/usr/src/linux-headers-${{ env.KERNEL_NAME }}
+          -DMODULES_KDIR=${{ env.KERNEL_NAME }}
+          -DLUA=TRUE -DSHAPER=FALSE -DRADIUS=TRUE ..
+      - name: make and install
+        working-directory: ./build
+        run: make && make install
+      - name: Start accel-ppp with default config
+        run: accel-pppd -d -c /etc/accel-ppp.conf.dist
+      - name: Sleep for 1 sec
+        run: sleep 1
+      - name: Check accel-ppp stat
+        run: accel-cmd show stat

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
             format: qcow2
 
           - distro: Debian13
-            image: https://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-generic-amd64-daily.tar.xz
+            image: https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.tar.xz
             untar: true
             format: raw
 


### PR DESCRIPTION
This PR has two ci improvements:
1. build for mainline kernel - it allows to check accel-ppp build on latest kernels (including -rc kernels)
2. debian13 is trixie so explicit name is used in ci job to avoid using debian unstable