### PR TITLE
log_tcp: Fix small memory leak

### DIFF
--- a/accel-pppd/logs/log_tcp.c
+++ b/accel-pppd/logs/log_tcp.c
@@ -288,6 +288,7 @@ static int start_log(const char *_opt)
 
 	list_add_tail(&t->entry, &targets);
 
+	free(opt);
 	return 0;
 
 err:


### PR DESCRIPTION
Discovered using clang sanitizers.