### PR TITLE
CMakeLists.txt: gentoo fix for __free_fn_t detection

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -48,6 +48,7 @@ ENDIF (RADIUS)
 INCLUDE (CheckCSourceCompiles)
 CHECK_C_SOURCE_COMPILES("
 #include <stdlib.h>
+#include <search.h>
 int main(void)
 {
 	__free_fn_t *f;


### PR DESCRIPTION
On Gentoo __free_fn_t wont be detected properly without this include.


Reported-by: Stanislav <stasn77@gmail.com>
Author: Stanislav <stasn77@gmail.com>