### PR TITLE
Fixes the issue #124 "HTTP replay for non SSTP query" and log_debug2 in Triton lib

### DIFF
--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -187,6 +187,7 @@ static unsigned int stat_active;
 static inline void sstp_queue(struct sstp_conn_t *conn, struct buffer_t *buf);
 static int sstp_send(struct sstp_conn_t *conn, struct buffer_t *buf);
 static inline void sstp_queue_deferred(struct sstp_conn_t *conn, struct buffer_t *buf);
+static int sstp_write(struct triton_md_handler_t *h);
 static int sstp_read_deferred(struct sstp_conn_t *conn);
 static int sstp_abort(struct sstp_conn_t *conn, int disconnect);
 static void sstp_disconnect(struct sstp_conn_t *conn);
@@ -858,7 +859,7 @@ static int http_send_response(struct sstp_conn_t *conn, char *proto, char *statu
 		}
 	}
 
-	return sstp_send(conn, buf);
+	return sstp_send(conn, buf) && sstp_write(&conn->hnd);
 }
 
 static int http_recv_request(struct sstp_conn_t *conn, uint8_t *data, int len)

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -1925,44 +1925,6 @@ static int sstp_handler(struct sstp_conn_t *conn, struct buffer_t *buf)
 	return 0;
 }
 
-static int sstp_write(struct triton_md_handler_t *h)
-{
-	struct sstp_conn_t *conn = container_of(h, typeof(*conn), hnd);
-	struct buffer_t *buf;
-	int n;
-
-	while (!list_empty(&conn->out_queue)) {
-		buf = list_first_entry(&conn->out_queue, typeof(*buf), entry);
-		while (buf->len) {
-			n = conn->stream->write(conn->stream, buf->head, buf->len);
-			if (n < 0) {
-				if (errno == EINTR)
-					continue;
-				if (errno == EAGAIN)
-					goto defer;
-				if (conf_verbose && errno != EPIPE)
-					log_ppp_info2("sstp: write: %s\n", strerror(errno));
-				goto drop;
-			} else if (n == 0)
-				goto defer;
-			buf_pull(buf, n);
-		}
-		list_del(&buf->entry);
-		free_buf(buf);
-	}
-
-	triton_md_disable_handler(h, MD_MODE_WRITE);
-	return 0;
-
-defer:
-	triton_md_enable_handler(h, MD_MODE_WRITE);
-	return 0;
-
-drop:
-	triton_context_call(&conn->ctx, (triton_event_func)sstp_disconnect, conn);
-	return 1;
-}
-
 static int sstp_read(struct triton_md_handler_t *h)
 {
 	struct sstp_conn_t *conn = container_of(h, typeof(*conn), hnd);
@@ -1994,7 +1956,6 @@ static int sstp_read(struct triton_md_handler_t *h)
 	return 0;
 
 drop:
-	n = sstp_write(h);
 	sstp_disconnect(conn);
 	return 1;
 }
@@ -2085,6 +2046,44 @@ static int sstp_recv(struct triton_md_handler_t *h)
 
 drop:
 	sstp_disconnect(conn);
+	return 1;
+}
+
+static int sstp_write(struct triton_md_handler_t *h)
+{
+	struct sstp_conn_t *conn = container_of(h, typeof(*conn), hnd);
+	struct buffer_t *buf;
+	int n;
+
+	while (!list_empty(&conn->out_queue)) {
+		buf = list_first_entry(&conn->out_queue, typeof(*buf), entry);
+		while (buf->len) {
+			n = conn->stream->write(conn->stream, buf->head, buf->len);
+			if (n < 0) {
+				if (errno == EINTR)
+					continue;
+				if (errno == EAGAIN)
+					goto defer;
+				if (conf_verbose && errno != EPIPE)
+					log_ppp_info2("sstp: write: %s\n", strerror(errno));
+				goto drop;
+			} else if (n == 0)
+				goto defer;
+			buf_pull(buf, n);
+		}
+		list_del(&buf->entry);
+		free_buf(buf);
+	}
+
+	triton_md_disable_handler(h, MD_MODE_WRITE);
+	return 0;
+
+defer:
+	triton_md_enable_handler(h, MD_MODE_WRITE);
+	return 0;
+
+drop:
+	triton_context_call(&conn->ctx, (triton_event_func)sstp_disconnect, conn);
 	return 1;
 }
 

--- a/accel-pppd/triton/triton.c
+++ b/accel-pppd/triton/triton.c
@@ -55,7 +55,7 @@ static __thread struct triton_context_t *this_ctx;
 static __thread jmp_buf jmp_env;
 static __thread void *thread_frame;
 
-//#define log_debug2(fmt, ...)
+#define log_debug2(fmt, ...)
 
 void triton_thread_wakeup(struct _triton_thread_t *thread)
 {

--- a/accel-pppd/triton/triton.c
+++ b/accel-pppd/triton/triton.c
@@ -55,7 +55,7 @@ static __thread struct triton_context_t *this_ctx;
 static __thread jmp_buf jmp_env;
 static __thread void *thread_frame;
 
-#define log_debug2(fmt, ...)
+//#define log_debug2(fmt, ...)
 
 void triton_thread_wakeup(struct _triton_thread_t *thread)
 {


### PR DESCRIPTION
This patch intends to fix HTTP mode neither returns 404 nor redirects to other URLs (as well as other statuses but 200 for SSTP). Discussed in #124. Also it removes define for log_debug2 function in Triton lib to make it actually log Triton events.