### PR TITLE
ci: remove debian10 support

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -85,7 +85,6 @@ jobs:
       matrix:
         distro:
           [
-            "debian:10",
             "debian:11",
             "debian:12",
             "debian:trixie",
@@ -105,7 +104,6 @@ jobs:
           debian:trixie) DISTRO=debian13; CPACK_TYPE=Debian13 ;;
           debian:12) DISTRO=debian12; CPACK_TYPE=Debian12 ;;
           debian:11) CPACK_TYPE=Debian11 ;;
-          debian:10) CPACK_TYPE=Debian10 ;;
           ubuntu:24.04) CPACK_TYPE=Ubuntu24 ; HEADERS_SUFFIX=generic ;;
           ubuntu:22.04) CPACK_TYPE=Ubuntu22 ; HEADERS_SUFFIX=generic ;;
           ubuntu:20.04) CPACK_TYPE=Ubuntu20 ; HEADERS_SUFFIX=generic ;;

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,11 +46,6 @@ jobs:
             untar: true
             format: raw
 
-          - distro: Debian10
-            image: https://cloud.debian.org/images/cloud/buster/latest/debian-10-generic-amd64.tar.xz
-            untar: true
-            format: raw
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -177,8 +172,6 @@ jobs:
 
       - name: Run tests (all)
         timeout-minutes: 5
-        # vlan-mon tests fail on Debian10 due to Debian10 bug so don't run all tests on deb10
-        if: ${{ matrix.distro != 'Debian10' }}
         run: >
           ssh -i ssh-key -p2222 user@localhost "cd accel-ppp/tests && 
           sudo python3 -m pytest -Wall -v"


### PR DESCRIPTION
Debian10 LTS is EoL (ref: https://wiki.debian.org/LTS) so it is removed from CI.
Debian10 ELTS is maintained by third-party organization, only some packages are maintained so there is no reason to support Debian10 in CI