### PR TITLE
ci: run tests in alpine vm

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -181,6 +181,136 @@ jobs:
           ssh -i ssh-key -p2222 user@localhost "ps aux | grep accel- && 
           sudo dmesg"
 
+  Test-in-Alpine:
+    #if: ${{ false }} # disable for now
+    runs-on: ubuntu-24.04
+    name: Test in Qemu (Alpine)
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: "accel-ppp"
+      - name: Install qemu and required tools
+        run: >
+          sudo apt update && 
+          NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true sudo -E apt -y install qemu-system-x86 qemu-utils cloud-image-utils cpu-checker cloud-image-utils wget openssh-client screen
+      - name: Check kvm support
+        run: sudo kvm-ok
+      - name: Prepare cloud-init image disk
+        run: |
+          ssh-keygen -t ed25519 -q -N "" -f ssh-key
+          echo "instance-id: $(uuidgen || echo i-abcdefg)" > init-meta
+          echo "#cloud-config" > init-data
+          echo "package_update: true" >> init-data
+          echo "package_upgrade: true" >> init-data
+          echo "package_reboot_if_required: false" >> init-data
+          echo "users:" >> init-data
+          echo "  - default" >> init-data
+          echo "  - name: alpine" >> init-data
+          echo "    shell: /bin/bash" >> init-data
+          echo "    ssh_authorized_keys:" >> init-data
+          echo "      - "`cat ssh-key.pub` >> init-data
+          echo "power_state:">> init-data
+          echo "    mode: poweroff">> init-data
+          cat init-data
+          cloud-localds init.img init-data init-meta
+      - name: Download and resize target OS cloud image
+        run: |
+          mkdir img
+          # we need to use metal image because virt image doesn't provide pppoe driver (https://gitlab.alpinelinux.org/alpine/aports/-/issues/13739)
+          wget -nv https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/cloud/nocloud_alpine-3.20.2-x86_64-bios-cloudinit-metal-r0.qcow2 -O img/image
+          qemu-img resize -f qcow2 img/`ls -1 img` +2G
+      - name: Run target OS first time (for cloud-init actions)
+        run: sudo qemu-system-x86_64 -enable-kvm -cpu host -m 4096 -nographic -drive format=qcow2,file=img/`ls -1 img` -drive format=raw,file=init.img
+      - name: Run target OS
+        run: sudo screen -dmS qemu qemu-system-x86_64 -enable-kvm -cpu host -net nic -net user,hostfwd=tcp::2222-:22 -m 4096 -nographic -drive format=qcow2,file=img/`ls -1 img`
+      - name: Check that target OS is running
+        run: |
+          sleep 1
+          sudo screen -ls
+      - name: Wait for ssh connection
+        timeout-minutes: 30
+        run: >
+          while ! ssh -o StrictHostKeyChecking=accept-new -p2222 -o ConnectTimeout=5 -i ssh-key alpine@localhost "exit 0";
+          do
+          echo "Trying to establish ssh connection";
+          sleep 5;
+          done;
+          cat ~/.ssh/known_hosts
+      - name: Display free space, current dir, kernel version and test doas
+        run: |
+          ssh -i ssh-key -p2222 alpine@localhost "df -h"
+          ssh -i ssh-key -p2222 alpine@localhost "pwd"
+          ssh -i ssh-key -p2222 alpine@localhost "uname -a"
+          ssh -i ssh-key -p2222 alpine@localhost "doas cat /etc/passwd"
+      - name: Install build tools (on target OS)
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "doas apk add --no-cache git cmake make g++ pcre-dev libressl-dev linux-headers libucontext-dev lua5.1-dev linux-lts-dev py3-pip 
+          ppp ppp-pppoe && 
+          (doas pip3 install pytest pytest-dependency pytest-order || doas pip3 install --break-system-packages pytest pytest-dependency pytest-order)"
+      - name: Copy source code to target OS
+        run: |
+          tar -Jcf accel-ppp.tar.xz accel-ppp
+          scp -i ssh-key -P2222 accel-ppp.tar.xz alpine@localhost:
+          ssh -i ssh-key -p2222 alpine@localhost "tar -xf accel-ppp.tar.xz"
+      - name: Build accel-ppp
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp &&
+          mkdir build && cd build &&
+          cmake -DBUILD_IPOE_DRIVER=TRUE -DBUILD_VLAN_MON_DRIVER=TRUE -DCMAKE_INSTALL_PREFIX=/usr 
+          -DKDIR=/usr/src/linux-headers-\`uname -r\` 
+          -DLUA=TRUE -DSHAPER=TRUE -DRADIUS=TRUE .. &&
+          make && doas make install"
+
+      - name: Run tests (not related to ipoe and vlan_mon drivers)
+        timeout-minutes: 5
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
+          doas python3 -m pytest -Wall --order-dependencies -v -m \"not ipoe_driver and not vlan_mon_driver\""
+      - name: Display processes and dmesg after tests
+        if: ${{ always() }}
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "ps aux | grep accel- && 
+          doas dmesg"
+
+      - name: Insert ipoe kernel module
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp &&
+          doas insmod build/drivers/ipoe/driver/ipoe.ko &&
+          lsmod | grep ipoe "
+
+      - name: Run tests (not related to vlan_mon drivers)
+        timeout-minutes: 5
+        if: ${{ always() }}
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
+          doas python3 -m pytest -Wall --order-dependencies -v -m \"not vlan_mon_driver\""
+      - name: Display processes and dmesg after tests
+        if: ${{ always() }}
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "ps aux | grep accel- && 
+          doas dmesg"
+
+      - name: Insert vlan_mon kernel module
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp &&
+          doas insmod build/drivers/vlan_mon/driver/vlan_mon.ko &&
+          lsmod | grep vlan_mon"
+
+      - name: Run tests (all)
+        timeout-minutes: 5
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
+          doas python3 -m pytest -Wall --order-dependencies -v"
+      - name: Display processes and dmesg after tests
+        if: ${{ always() }}
+        run: >
+          ssh -i ssh-key -p2222 alpine@localhost "ps aux | grep accel- && 
+          doas dmesg"
+
+
   Test-in-GH:
     #if: ${{ false }} # disable for now
     strategy:

--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -71,6 +71,19 @@ IF (HAVE_GOOD_IFARP)
 	ADD_DEFINITIONS(-DHAVE_GOOD_IFARP)
 ENDIF (HAVE_GOOD_IFARP)
 
+INCLUDE (CheckCSourceCompiles)
+CHECK_C_SOURCE_COMPILES("
+#include <utmp.h>
+int main(void)
+{
+	logwtmp(\"\", \"\", \"\");
+	return 0;
+}" HAVE_LOGWTMP)
+
+IF (HAVE_LOGWTMP)
+	ADD_DEFINITIONS(-DHAVE_LOGWTMP)
+ENDIF (HAVE_LOGWTMP)
+
 
 ADD_SUBDIRECTORY(triton)
 ADD_SUBDIRECTORY(vlan-mon)

--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -6,6 +6,9 @@ log_file
 
 connlimit
 
+radius
+#chap-secrets
+
 pptp
 l2tp
 #sstp
@@ -16,9 +19,6 @@ auth_mschap_v2
 auth_mschap_v1
 auth_chap_md5
 auth_pap
-
-radius
-#chap-secrets
 
 ippool
 

--- a/accel-pppd/extra/logwtmp.c
+++ b/accel-pppd/extra/logwtmp.c
@@ -14,6 +14,7 @@
 #include "memdebug.h"
 
 
+#ifdef HAVE_LOGWTMP
 static void ev_ses_started(struct ap_session *ses)
 {
 	logwtmp(ses->ifname, ses->username ?: "", ses->ctrl->calling_station_id);
@@ -29,5 +30,11 @@ static void init(void)
 	triton_event_register_handler(EV_SES_STARTED, (triton_event_func)ev_ses_started);
 	triton_event_register_handler(EV_SES_FINISHED, (triton_event_func)ev_ses_finished);
 }
+#else
+static void init(void)
+{
+    log_warn("logwtmp is not supported on your platfrom, check libc doc\n");
+}
+#endif
 
 DEFINE_INIT(200, init);

--- a/tests/accel-pppd/general/test_basic.py
+++ b/tests/accel-pppd/general/test_basic.py
@@ -19,9 +19,11 @@ def accel_pppd_config():
     log_tcp
     #log_pgsql
 
+    connlimit
     pptp
     l2tp
     sstp
+    radius
     pppoe
     ipoe
 
@@ -30,7 +32,6 @@ def accel_pppd_config():
     auth_chap_md5
     auth_pap
 
-    radius
     chap-secrets
 
     ippool
@@ -39,7 +40,6 @@ def accel_pppd_config():
     shaper
     #net-snmp
     logwtmp
-    connlimit
 
     ipv6_nd
     ipv6_dhcp

--- a/tests/accel-pppd/general/test_pcre_negative_cases.py
+++ b/tests/accel-pppd/general/test_pcre_negative_cases.py
@@ -6,14 +6,24 @@ from common import process
 def accel_pppd_config():
     return """
     [modules]
+    radius
     pppoe
+
+    [core]
+    log-error=/dev/stderr
 
     [log]
     log-debug=/dev/stdout
+    log-file=/dev/stdout
+    log-emerg=/dev/stderr
     level=5
 
     [cli]
     tcp=127.0.0.1:2001
+
+    [radius]
+
+    [pppoe]
     """
 
 

--- a/tests/accel-pppd/ipoe/dhcpv4/test_ipoe_shared_session_wo_auth.py
+++ b/tests/accel-pppd/ipoe/dhcpv4/test_ipoe_shared_session_wo_auth.py
@@ -9,7 +9,8 @@ def accel_pppd_config(veth_pair_netns):
     return (
         """
     [modules]
-    pppoe
+    connlimit
+    radius
     ipoe
     ippool
 
@@ -20,9 +21,16 @@ def accel_pppd_config(veth_pair_netns):
     [cli]
     tcp=127.0.0.1:2001
 
+    [core]
+    log-error=/dev/stderr
+
     [log]
     log-debug=/dev/stdout
+    log-file=/dev/stdout
+    log-emerg=/dev/stderr
     level=5
+
+    [radius]
 
     [ipoe]
     noauth=1

--- a/tests/accel-pppd/pppoe/conftest.py
+++ b/tests/accel-pppd/pppoe/conftest.py
@@ -1,5 +1,6 @@
-import pytest
+import pytest, subprocess, re
 from common import pppd_process
+from packaging.version import Version
 
 # pppd executable file name
 @pytest.fixture()
@@ -13,11 +14,21 @@ def pppd(pytestconfig):
 def pppd_config():
     return ""
 
+# determines which plugin is required - pppoe.so (pppd 2.5.0+) or rp-pppoe.so (pppd <2.5.0)
+def pppd_plugin_so(pppd):
+    command = [pppd, "--version"]
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    pppd_version = Version(re.search(r'\d+\.\d+\.\d+', result.stdout + result.stderr).group())
+    ref_version = Version("2.5.0")
+    if pppd_version >= ref_version:
+        return "pppoe.so"
+    else:
+        return "rp-pppoe.so"
 
 # pppd configuration as command line args
 @pytest.fixture()
-def pppd_args(pppd_config):
-    return pppd_config.split()
+def pppd_args(pppd_config, pppd):
+    return ("plugin " + pppd_plugin_so(pppd) + "\n" + pppd_config).split()
 
 
 # setup and teardown for tests that required running pppd (after accel-pppd)

--- a/tests/accel-pppd/pppoe/test_pppoe_disc.py
+++ b/tests/accel-pppd/pppoe/test_pppoe_disc.py
@@ -8,14 +8,22 @@ def accel_pppd_config(veth_pair_netns):
     return (
         """
     [modules]
+    radius
     pppoe
+
+    [core]
+    log-error=/dev/stderr
 
     [log]
     log-debug=/dev/stdout
+    log-file=/dev/stdout
+    log-emerg=/dev/stderr
     level=5
 
     [cli]
     tcp=127.0.0.1:2001
+
+    [radius]
 
     [pppoe]
     ac-name=test-accel

--- a/tests/accel-pppd/pppoe/test_pppoe_pado_delay.py
+++ b/tests/accel-pppd/pppoe/test_pppoe_pado_delay.py
@@ -30,14 +30,22 @@ def accel_pppd_config(veth_pair_netns):
     return (
         """
     [modules]
+    radius
     pppoe
+
+    [core]
+    log-error=/dev/stderr
 
     [log]
     log-debug=/dev/stdout
+    log-file=/dev/stdout
+    log-emerg=/dev/stderr
     level=5
 
     [cli]
     tcp=127.0.0.1:2001
+
+    [radius]
 
     [pppoe]
     ac-name=test-accel

--- a/tests/accel-pppd/pppoe/test_pppoe_session_wo_auth.py
+++ b/tests/accel-pppd/pppoe/test_pppoe_session_wo_auth.py
@@ -9,12 +9,18 @@ def accel_pppd_config(veth_pair_netns):
     return (
         """
     [modules]
+    radius
     pppoe
     auth_pap
     ippool
 
+    [core]
+    log-error=/dev/stderr
+
     [log]
     log-debug=/dev/stdout
+    log-file=/dev/stdout
+    log-emerg=/dev/stderr
     level=5
 
     [auth]
@@ -26,6 +32,8 @@ def accel_pppd_config(veth_pair_netns):
 
     [cli]
     tcp=127.0.0.1:2001
+
+    [radius]
 
     [pppoe]
     interface="""
@@ -47,7 +55,6 @@ def pppd_config(veth_pair_netns):
     mtu 1492
     noaccomp
     default-asyncmap
-    plugin rp-pppoe.so
     user loginAB
     password pass123
     nic-"""

--- a/tests/accel-pppd/pppoe/test_pppoe_vlan_mon.py
+++ b/tests/accel-pppd/pppoe/test_pppoe_vlan_mon.py
@@ -13,14 +13,22 @@ def accel_pppd_config(veth_pair_netns):
     print(veth_pair_netns)
     return """
     [modules]
+    radius
     pppoe
+
+    [core]
+    log-error=/dev/stderr
 
     [log]
     log-debug=/dev/stdout
+    log-file=/dev/stdout
+    log-emerg=/dev/stderr
     level=5
 
     [cli]
     tcp=127.0.0.1:2001
+
+    [radius]
 
     [pppoe]
     ac-name=test-accel


### PR DESCRIPTION
Alpine Linux uses musl libc so now accel-ppp is tested under musl

Currently, Alpine Linux doesn't provide a link to the latest stable version so direct link to Alpine 3.20 is used

Improved musl support might be used to run on platforms like openwrt without additional patches