### PR TITLE
build: fix compile errors on GCC 14

### DIFF
--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -161,7 +161,7 @@ struct dhcpv4_serv *dhcpv4_create(struct triton_context_t *ctx, const char *ifna
 		goto out_err;
 	}
 
-	if (bind(sock, &addr, sizeof(addr))) {
+	if (bind(sock, (struct sockaddr*)&addr, sizeof(addr))) {
 		log_error("bind: %s\n", strerror(errno));
 		goto out_err;
 	}
@@ -1012,12 +1012,12 @@ struct dhcpv4_relay *dhcpv4_relay_create(const char *_addr, in_addr_t giaddr, st
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &f, sizeof(f)))
 		log_error("dhcpv4: setsockopt(SO_REUSEADDR): %s\n", strerror(errno));
 
-	if (bind(sock, &laddr, sizeof(laddr))) {
+	if (bind(sock, (struct sockaddr*)&laddr, sizeof(laddr))) {
 		log_error("dhcpv4: relay: %s: bind: %s\n", _addr, strerror(errno));
 		goto out_err_unlock;
 	}
 
-	if (connect(sock, &raddr, sizeof(raddr))) {
+	if (connect(sock, (struct sockaddr*)&raddr, sizeof(raddr))) {
 		log_error("dhcpv4: relay: %s: connect: %s\n", _addr, strerror(errno));
 		goto out_err_unlock;
 	}

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -3109,12 +3109,12 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 
 		sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
-		if (connect(sock, &addr, sizeof(addr))) {
+		if (connect(sock, (struct sockaddr*)&addr, sizeof(addr))) {
 			log_error("dhcpv4: relay: %s: connect: %s\n", opt_relay, strerror(errno));
 			goto out_err;
 		}
 
-		getsockname(sock, &addr, &len);
+		getsockname(sock, (struct sockaddr*)&addr, &len);
 		opt_giaddr = addr.sin_addr.s_addr;
 
 		close(sock);

--- a/accel-pppd/ctrl/l2tp/l2tp.c
+++ b/accel-pppd/ctrl/l2tp/l2tp.c
@@ -1613,7 +1613,7 @@ static struct l2tp_conn_t *l2tp_tunnel_alloc(const struct sockaddr_in *peer,
 			  strerror(errno));
 		goto err_conn_fd;
 	}
-	if (bind(conn->hnd.fd, host, sizeof(*host))) {
+	if (bind(conn->hnd.fd, (struct sockaddr*)host, sizeof(*host))) {
 		log_error("l2tp: impossible to allocate new tunnel:"
 			  " bind() failed: %s\n", strerror(errno));
 		goto err_conn_fd;
@@ -1646,7 +1646,7 @@ static struct l2tp_conn_t *l2tp_tunnel_alloc(const struct sockaddr_in *peer,
 		goto err_conn_fd;
 	}
 
-	if (getsockname(conn->hnd.fd, &conn->host_addr, &hostaddrlen) < 0) {
+	if (getsockname(conn->hnd.fd, (struct sockaddr*)&conn->host_addr, &hostaddrlen) < 0) {
 		log_error("l2tp: impossible to allocate new tunnel:"
 			  " getsockname() failed: %s\n", strerror(errno));
 		goto err_conn_fd;
@@ -1747,7 +1747,7 @@ static inline int l2tp_tunnel_update_peerport(struct l2tp_conn_t *conn,
 	int res;
 
 	conn->peer_addr.sin_port = port_nbo;
-	res = connect(conn->hnd.fd, &conn->peer_addr, sizeof(conn->peer_addr));
+	res = connect(conn->hnd.fd, (struct sockaddr*)&conn->peer_addr, sizeof(conn->peer_addr));
 	if (res < 0) {
 		log_tunnel(log_error, conn,
 			   "impossible to update peer port from %hu to %hu:"

--- a/accel-pppd/ctrl/l2tp/packet.c
+++ b/accel-pppd/ctrl/l2tp/packet.c
@@ -280,7 +280,7 @@ int l2tp_recv(int fd, struct l2tp_packet_t **p, struct in_pktinfo *pkt_info,
 	ptr = (uint8_t *)(hdr + 1);
 
 	addr_len = sizeof(addr);
-	n = recvfrom(fd, buf, L2TP_MAX_PACKET_SIZE, 0, &addr, &addr_len);
+	n = recvfrom(fd, buf, L2TP_MAX_PACKET_SIZE, 0, (struct sockaddr*)&addr, &addr_len);
 	if (n < 0) {
 		mempool_free(buf);
 		if (errno == EAGAIN) {
@@ -552,7 +552,7 @@ int l2tp_packet_send(int sock, struct l2tp_packet_t *pack)
 	memcpy(buf, &pack->hdr, sizeof(pack->hdr));
 	hdr->flags = htons(pack->hdr.flags);
 
-	n = sendto(sock, buf, len, 0, &pack->addr, sizeof(pack->addr));
+	n = sendto(sock, buf, len, 0, (struct sockaddr*)&pack->addr, sizeof(pack->addr));
 	mempool_free(buf);
 
 	if (n < 0) {

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -708,7 +708,7 @@ static int pptp_connect(struct triton_md_handler_t *h)
 		conn->ctrl.calling_station_id = _malloc(17);
 		conn->ctrl.called_station_id = _malloc(17);
 		u_inet_ntoa(addr.sin_addr.s_addr, conn->ctrl.calling_station_id);
-		getsockname(sock, &addr, &size);
+		getsockname(sock, (struct sockaddr*)&addr, &size);
 		u_inet_ntoa(addr.sin_addr.s_addr, conn->ctrl.called_station_id);
 
 		ppp_init(&conn->ppp);

--- a/accel-pppd/logs/log_tcp.c
+++ b/accel-pppd/logs/log_tcp.c
@@ -163,7 +163,7 @@ static int log_tcp_connect(struct triton_md_handler_t *h)
 {
 	struct tcp_target_t *t = container_of(h, typeof(*t), hnd);
 
-	if (connect(t->hnd.fd, &t->addr, sizeof(t->addr))) {
+	if (connect(t->hnd.fd, (struct sockaddr*)&t->addr, sizeof(t->addr))) {
 		if (errno == EAGAIN)
 			return 0;
 		if (errno == EINPROGRESS)
@@ -216,7 +216,7 @@ static void start_connect(struct tcp_target_t *t)
     return;
 	}
 
-	if (connect(t->hnd.fd, &t->addr, sizeof(t->addr))) {
+	if (connect(t->hnd.fd, (struct sockaddr*)&t->addr, sizeof(t->addr))) {
 		if (errno != EINPROGRESS) {
 			log_emerg("log-tcp: connect: %s\n", strerror(errno));
 			close(t->hnd.fd);

--- a/accel-pppd/radius/packet.c
+++ b/accel-pppd/radius/packet.c
@@ -139,7 +139,7 @@ int rad_packet_recv(int fd, struct rad_packet_t **p, struct sockaddr_in *addr)
 
 	while (1) {
 		if (addr)
-			n = recvfrom(fd, pack->buf, REQ_LENGTH_MAX, 0, addr, &addr_len);
+			n = recvfrom(fd, pack->buf, REQ_LENGTH_MAX, 0, (struct sockaddr *)addr, &addr_len);
 		else
 			n = read(fd, pack->buf, REQ_LENGTH_MAX);
 		if (n < 0) {
@@ -813,7 +813,7 @@ int rad_packet_send(struct rad_packet_t *pack, int fd, struct sockaddr_in *addr)
 
 	while (1) {
 		if (addr)
-			n = sendto(fd, pack->buf, pack->len, 0, addr, sizeof(*addr));
+			n = sendto(fd, pack->buf, pack->len, 0, (struct sockaddr *)addr, sizeof(*addr));
 		else
 			n = write(fd, pack->buf, pack->len);
 		if (n < 0) {


### PR DESCRIPTION
This patch fixes compile errors on GCC 14 like the following

```
/root/accel-ppp/accel-pppd/radius/packet.c: In function 'rad_packet_recv': /root/accel-ppp/accel-pppd/radius/packet.c:142:72: error: passing argument 5 of 'recvfrom' from incompatible pointer type [-Wincompatible-pointer-types]
  142 |                         n = recvfrom(fd, pack->buf, REQ_LENGTH_MAX, 0, addr, &addr_len);
      |                                                                        ^~~~
      |                                                                        |
      |                                                                        struct sockaddr_in *
In file included from /usr/include/netinet/in.h:10,
                 from /usr/include/arpa/inet.h:9,
                 from /root/accel-ppp/accel-pppd/radius/packet.c:10:
/usr/include/sys/socket.h:397:55: note: expected 'struct sockaddr * restrict' but argument is of type 'struct sockaddr_in *'
```

Reference: https://gcc.gnu.org/gcc-14/porting_to.html