### PR TITLE
build: fix build for entware (HAVE_GOOD_IFARP detection issue)

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -60,6 +60,7 @@ ENDIF (HAVE_FREE_FN_T)
 
 INCLUDE (CheckCSourceCompiles)
 CHECK_C_SOURCE_COMPILES("
+#include <sys/socket.h>
 #include <linux/if_arp.h>
 #include <net/ethernet.h>
 int main(void)


### PR DESCRIPTION
Linux kernel before 4.11 has the issue decribed in the commit: https://github.com/torvalds/linux/commit/2618be7dccf8739b89e1906b64bd8d551af351e6

It fails accel-ppp build on entware. Let's include sys/socket.h to avoid this issue. All files that use linux/if_arp.h includes sys/socket.h before

Related to https://github.com/orgs/accel-ppp/discussions/187