### PR TITLE
pppoe: fix #189

### DIFF
--- a/accel-pppd/ctrl/pppoe/CMakeLists.txt
+++ b/accel-pppd/ctrl/pppoe/CMakeLists.txt
@@ -13,7 +13,13 @@ SET(sources ${sources} tr101.c)
 ENDIF(RADIUS)
 
 ADD_LIBRARY(pppoe SHARED ${sources})
-TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit)
+
+IF (RADIUS)
+	TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit radius)
+ELSE (RADIUS)
+	TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit)
+ENDIF (RADIUS)
+
 set_property(TARGET pppoe PROPERTY CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set_property(TARGET pppoe PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/accel-ppp)
 


### PR DESCRIPTION
Tested on Entware. Now it is possible to use chap-secrets authentication with pppoe. Refer to the linked issue for info.

Closes: #189 