### PR TITLE
Revert "Fix #189: Make module pppoe work without module radius"

### DIFF
--- a/accel-pppd/ctrl/pppoe/CMakeLists.txt
+++ b/accel-pppd/ctrl/pppoe/CMakeLists.txt
@@ -13,13 +13,7 @@ SET(sources ${sources} tr101.c)
 ENDIF(RADIUS)
 
 ADD_LIBRARY(pppoe SHARED ${sources})
-
-IF (RADIUS)
-	TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit radius)
-ELSE (RADIUS)
-	TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit)
-ENDIF (RADIUS)
-
+TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit)
 set_property(TARGET pppoe PROPERTY CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set_property(TARGET pppoe PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/accel-ppp)
 


### PR DESCRIPTION
This reverts commit 543700aed1ac045f12dfafd898bbbbae955fee31 (PR #190) .