### PR TITLE
fix(ppp_lcp): truncate echo reply if size > client MRU

### DIFF
--- a/accel-pppd/ppp/ppp_lcp.c
+++ b/accel-pppd/ppp/ppp_lcp.c
@@ -16,6 +16,10 @@
 
 #include "memdebug.h"
 
+#ifndef min
+#define min(x,y) ((x)<(y)?(x):(y))
+#endif
+
 struct recv_opt_t
 {
 	struct list_head entry;
@@ -615,7 +619,7 @@ static void send_echo_reply(struct ppp_lcp_t *lcp)
 	if (conf_ppp_verbose)
 		log_ppp_debug("send [LCP EchoRep id=%x <magic %08x>]\n", hdr->id, lcp->magic);
 
-	ppp_chan_send(lcp->ppp, hdr, ntohs(hdr->len) + 2);
+	ppp_chan_send(lcp->ppp, hdr, min(ntohs(hdr->len), lcp->ppp->mtu) + 2);
 }
 
 static void send_echo_request(struct triton_timer_t *t)


### PR DESCRIPTION
Closes #204

The size of the LCP Echo-Reply is determined by selecting the minimum between  the Echo-Request size, and the client's MRU.  
Re-using the example of the issue #204 , this allows to have Request - Reply of this kind, complying with RFC1171:
```
PPPoE  [ses 0x2fc0] LCP (0xc021), length 1494: LCP, Echo-Request (0x09), id 0, length 1494
PPPoE  [ses 0x2fc0] LCP (0xc021), length 1482: LCP, Echo-Reply (0x0a), id 0, length 1482
```
 