### PR TITLE
Fix post_msg implementation bug

### DIFF
--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -142,8 +142,8 @@ again:
 			if (errno != EPIPE) {
 				if (conf_verbose)
 					log_ppp_info2("pptp: write: %s\n", strerror(errno));
-				return -1;
 			}
+			return -1;
 		}
 	}
 


### PR DESCRIPTION
I think the error handling code of `post_msg` is wrongly implemented due to coding typo. The `EPIPE` should be also considered and then return -1, just like `PPTP_write`: 
https://github.com/accel-ppp/accel-ppp/blob/1b8711cf75a7c278d99840112bc7a396398e0205/accel-pppd/ctrl/pptp/pptp.c#L539-L570

This pr fix https://github.com/xebd/accel-ppp/issues/158