### PR TITLE
tests,ci: disable chap-secrets related tests on alpine

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -270,7 +270,7 @@ jobs:
         timeout-minutes: 5
         run: >
           ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
-          doas python3 -m pytest -Wall --order-dependencies -v -m \"not ipoe_driver and not vlan_mon_driver\""
+          doas python3 -m pytest -Wall --order-dependencies -v -m \"not ipoe_driver and not vlan_mon_driver and not chap_secrets\""
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: >
@@ -288,7 +288,7 @@ jobs:
         if: ${{ always() }}
         run: >
           ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
-          doas python3 -m pytest -Wall --order-dependencies -v -m \"not vlan_mon_driver\""
+          doas python3 -m pytest -Wall --order-dependencies -v -m \"not vlan_mon_driver and not chap_secrets\""
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: >
@@ -305,7 +305,7 @@ jobs:
         timeout-minutes: 5
         run: >
           ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
-          doas python3 -m pytest -Wall --order-dependencies -v"
+          doas python3 -m pytest -Wall --order-dependencies -v -m \"not chap_secrets\""
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: >

--- a/tests/accel-pppd/ipoe/dhcpv4/test_ipoe_shared_session_chap_secrets.py
+++ b/tests/accel-pppd/ipoe/dhcpv4/test_ipoe_shared_session_chap_secrets.py
@@ -54,6 +54,7 @@ def accel_pppd_config(veth_pair_netns, chap_secrets_config_file):
 # test dhcpv4 shared session without auth check
 @pytest.mark.dependency(depends=["ipoe_driver_loaded"], scope="session")
 @pytest.mark.ipoe_driver
+@pytest.mark.chap_secrets
 def test_ipoe_shared_session_chap_secrets(
     dhclient_instance, accel_cmd, veth_pair_netns
 ):

--- a/tests/accel-pppd/ipoe/dhcpv4/test_ipoe_shared_session_lua_chap_secrets.py
+++ b/tests/accel-pppd/ipoe/dhcpv4/test_ipoe_shared_session_lua_chap_secrets.py
@@ -74,6 +74,7 @@ def accel_pppd_config(veth_pair_netns, chap_secrets_config_file, lua_script_file
 # test dhcpv4 shared session without auth check
 @pytest.mark.dependency(depends=["ipoe_driver_loaded"], scope="session")
 @pytest.mark.ipoe_driver
+@pytest.mark.chap_secrets
 def test_ipoe_shared_session_lua_chap_secrets(
     dhclient_instance, accel_cmd, veth_pair_netns
 ):

--- a/tests/accel-pppd/pppoe/test_pppoe_session_chap_secrets.py
+++ b/tests/accel-pppd/pppoe/test_pppoe_session_chap_secrets.py
@@ -68,6 +68,7 @@ def pppd_config(veth_pair_netns):
 
 
 # test pppoe session without auth check
+@pytest.mark.chap_secrets
 def test_pppoe_session_chap_secrets(pppd_instance, accel_cmd):
 
     # test that pppd (with accel-pppd) started successfully

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,10 @@ def pytest_configure(config):
         "markers",
         "vlan_mon_driver: marks tests as related to ipoe kernel module (deselect with '-m \"not vlan_mon_driver\"')",
     )
+    config.addinivalue_line(
+        "markers",
+        "chap_secrets: marks tests as related to chap-secrets module (deselect with '-m \"not chap_secrets\"')",
+    )
 
 
 # accel-pppd executable file name


### PR DESCRIPTION
radius and chap-secrets can't work together due to musl library limiations
This patch disables chap-secrets related tests on alpine

ref: https://github.com/accel-ppp/accel-ppp/pull/190#issuecomment-2331036461