### PR TITLE
ipoe: fix driver for kernel 6.12 (NETIF_F_NETNS_LOCAL)

### DIFF
--- a/drivers/ipoe/ipoe.c
+++ b/drivers/ipoe/ipoe.c
@@ -1105,7 +1105,11 @@ static void ipoe_netdev_setup(struct net_device *dev)
 	dev->iflink = 0;
 #endif
 	dev->addr_len = ETH_ALEN;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+	dev->netns_local = true;
+#else
 	dev->features  |= NETIF_F_NETNS_LOCAL;
+#endif
 	dev->features  &= ~(NETIF_F_HW_VLAN_FILTER | NETIF_F_LRO);
 	dev->header_ops	= &ipoe_hard_header_ops;
 	dev->priv_flags &= ~IFF_XMIT_DST_RELEASE;


### PR DESCRIPTION
Closes: https://github.com/accel-ppp/accel-ppp/issues/217
Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=05c1280a2bcfca187fe7fa90bb240602cf54af0a
Ref: https://github.com/torvalds/linux/commit/05c1280a2bcfca187fe7fa90bb240602cf54af0a

Reported-By: https://github.com/axe-kenig

CI run for kernel 6.12 (alpine edge): https://github.com/svlobanov/accel-ppp/actions/runs/12100376477/job/33738894243?pr=22