### PR TITLE
IPv6CP: Don't terminate whole PPPoE session by Client IPV6CP TermReq

### DIFF
--- a/accel-pppd/ppp/ppp_ipv6cp.c
+++ b/accel-pppd/ppp/ppp_ipv6cp.c
@@ -738,7 +738,10 @@ static void ipv6cp_recv(struct ppp_handler_t*h)
 			if (conf_ppp_verbose)
 				log_ppp_info2("recv [IPV6CP TermReq id=%x]\n", hdr->id);
 			ppp_fsm_recv_term_req(&ipv6cp->fsm);
-			ap_session_terminate(&ipv6cp->ppp->ses, TERM_USER_REQUEST, 0);
+			if (conf_ipv4 == IPV4_REQUIRE)
+				ap_session_terminate(&ipv6cp->ppp->ses, TERM_USER_REQUEST, 0);
+			else
+				ppp_layer_passive(ipv6cp->ppp, &ipv6cp->ld);
 			break;
 		case TERMACK:
 			if (conf_ppp_verbose)


### PR DESCRIPTION
Session will terminates only when [ppp]ipv6=require configured