### PR TITLE
(workflows): Ubuntu 20.04 is deprecated, removing it

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: ubuntu-20.04
-            pkg-distro: ubuntu20.04
-            cpack-type: Ubuntu20
           - distro: ubuntu-22.04
             pkg-distro: ubuntu22.04
             cpack-type: Ubuntu22

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ["ubuntu-24.04", "ubuntu-22.04", "ubuntu-20.04"]
+        distro: ["ubuntu-24.04", "ubuntu-22.04"]
 
     runs-on: ${{ matrix.distro }}
     steps:
@@ -239,7 +239,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ["ubuntu-24.04", "ubuntu-22.04", "ubuntu-20.04"]
+        distro: ["ubuntu-24.04", "ubuntu-22.04"]
 
     runs-on: ${{ matrix.distro }}
     steps:


### PR DESCRIPTION
This tests failing now with following message:
```
This is a scheduled Ubuntu 20.04 retirement.
Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
For more details, see https://github.com/actions/runner-images/issues/11101
```