### PR TITLE
feat(build): Add MUSL detection and conditional linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,21 @@ IF (NOT DEFINED LIB_SUFFIX)
 	ENDIF (ARCH STREQUAL x86_64)
 ENDIF (NOT DEFINED LIB_SUFFIX)
 
+# Set flag if we are building with MUSL
+IF (CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_C_COMPILER_ID STREQUAL GNU)
+    execute_process(
+        COMMAND sh -c "ldd --version 2>&1 || true"
+        OUTPUT_VARIABLE LDD_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+	if (LDD_VERSION MATCHES "[Mm]usl")
+		set(MUSL ON)
+	else ()
+		set(MUSL OFF)
+	endif ()
+	message(STATUS "Building with MUSL: ${MUSL}")
+ENDIF (CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_C_COMPILER_ID STREQUAL GNU)
+
 #color console example  message(FATAL_ERROR "${Esc}[31m Red Text ${Esc}[m Restore Normal Text")
 string(ASCII 27 Esc)
 

--- a/accel-pppd/ctrl/pppoe/CMakeLists.txt
+++ b/accel-pppd/ctrl/pppoe/CMakeLists.txt
@@ -13,7 +13,12 @@ SET(sources ${sources} tr101.c)
 ENDIF(RADIUS)
 
 ADD_LIBRARY(pppoe SHARED ${sources})
-TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit)
+# if MUSL is set then we need to link with the connlimit library
+IF (MUSL)
+	TARGET_LINK_LIBRARIES(pppoe vlan-mon connlimit)
+ELSE (MUSL)
+	TARGET_LINK_LIBRARIES(pppoe vlan-mon)
+ENDIF (MUSL)
 set_property(TARGET pppoe PROPERTY CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set_property(TARGET pppoe PROPERTY INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/accel-ppp)
 


### PR DESCRIPTION
This commit introduces the ability to detect if the project is being built with the MUSL C library.

A new variable `MUSL` is set to `ON` if MUSL is detected, and `OFF` otherwise. This is achieved by checking the output of `ldd --version`.

The `accel-pppd/ctrl/pppoe/CMakeLists.txt` file is updated to conditionally link the `connlimit` library only when building with MUSL.