### PR TITLE
IPv6 supports both stateful and stateless scenarios

### DIFF
--- a/accel-pppd/ipv6/nd.c
+++ b/accel-pppd/ipv6/nd.c
@@ -33,8 +33,8 @@ static int conf_dnssl_size;
 
 static int conf_MaxRtrAdvInterval = 600;
 static int conf_MinRtrAdvInterval;
-static int conf_AdvManagedFlag;
-static int conf_AdvOtherConfigFlag;
+static int conf_AdvManagedFlag = 1;
+static int conf_AdvOtherConfigFlag = 1;
 static int conf_AdvLinkMTU;
 static int conf_AdvReachableTime;
 static int conf_AdvRetransTimer;
@@ -132,18 +132,20 @@ static void ipv6_nd_send_ra(struct ipv6_nd_handler_t *h, struct sockaddr_in6 *ds
 	pinfo = (struct nd_opt_prefix_info *)(adv + 1);
 	list_for_each_entry(a, &ses->ipv6->addr_list, entry) {
 		prefix_len = a->prefix_len == 128 ? 64 : a->prefix_len;
-		memset(pinfo, 0, sizeof(*pinfo));
-		pinfo->nd_opt_pi_type = ND_OPT_PREFIX_INFORMATION;
-		pinfo->nd_opt_pi_len = 4;
-		pinfo->nd_opt_pi_prefix_len = prefix_len;
-		pinfo->nd_opt_pi_flags_reserved =
-			((a->flag_onlink || conf_AdvPrefixOnLinkFlag) ? ND_OPT_PI_FLAG_ONLINK : 0) |
-			((a->flag_auto || (conf_AdvPrefixAutonomousFlag && prefix_len == 64)) ? ND_OPT_PI_FLAG_AUTO : 0);
-		pinfo->nd_opt_pi_valid_time = htonl(conf_AdvPrefixValidLifetime);
-		pinfo->nd_opt_pi_preferred_time = htonl(conf_AdvPrefixPreferredLifetime);
-		memcpy(&pinfo->nd_opt_pi_prefix, &a->addr, (prefix_len + 7) / 8);
-		pinfo->nd_opt_pi_prefix.s6_addr[prefix_len / 8] &= ~(0xff >> (prefix_len % 8));
-		pinfo++;
+		if (conf_AdvPrefixAutonomousFlag) {
+			memset(pinfo, 0, sizeof(*pinfo));
+			pinfo->nd_opt_pi_type = ND_OPT_PREFIX_INFORMATION;
+			pinfo->nd_opt_pi_len = 4;
+			pinfo->nd_opt_pi_prefix_len = prefix_len;
+			pinfo->nd_opt_pi_flags_reserved =
+				((a->flag_onlink || conf_AdvPrefixOnLinkFlag) ? ND_OPT_PI_FLAG_ONLINK : 0) |
+				((a->flag_auto || (conf_AdvPrefixAutonomousFlag && prefix_len == 64)) ? ND_OPT_PI_FLAG_AUTO : 0);
+			pinfo->nd_opt_pi_valid_time = htonl(conf_AdvPrefixValidLifetime);
+			pinfo->nd_opt_pi_preferred_time = htonl(conf_AdvPrefixPreferredLifetime);
+			memcpy(&pinfo->nd_opt_pi_prefix, &a->addr, (prefix_len + 7) / 8);
+			pinfo->nd_opt_pi_prefix.s6_addr[prefix_len / 8] &= ~(0xff >> (prefix_len % 8));
+			pinfo++;
+		}
 
 		if (!a->installed) {
 			if (a->prefix_len == 128) {
@@ -174,7 +176,7 @@ static void ipv6_nd_send_ra(struct ipv6_nd_handler_t *h, struct sockaddr_in6 *ds
 		rinfo++;
 	}*/
 
-	if (conf_dns_count) {
+	if (((conf_AdvManagedFlag && conf_AdvOtherConfigFlag && conf_AdvPrefixAutonomousFlag) || (!conf_AdvManagedFlag && !conf_AdvOtherConfigFlag && conf_AdvPrefixAutonomousFlag)) && conf_dns_count) {
 		rdnssinfo = (struct nd_opt_rdnss_info_local *)pinfo;
 		memset(rdnssinfo, 0, sizeof(*rdnssinfo));
 		rdnssinfo->nd_opt_rdnssi_type = ND_OPT_RDNSS_INFORMATION;


### PR DESCRIPTION
IPv6 supports both stateful and stateless scenarios, as well as scenarios where M and O are both set to 1.
IPv6 support not have pd prefix, reply D6_STATUS_NoPrefixAvail