### PR TITLE
pppoe: add missing break, ignore vendor-specific tags when parsing PADR

### DIFF
--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -1194,6 +1194,7 @@ static void pppoe_recv_PADR(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 				if (vendor_id == VENDOR_ADSL_FORUM)
 					if (conf_tr101)
 						tr101_tag = tag;
+				break;
 			case TAG_PPP_MAX_PAYLOAD:
 				if (ntohs(tag->tag_len) == 2)
 					ppp_max_payload = ntohs(*(uint16_t *)tag->tag_data);


### PR DESCRIPTION
Added an explicit break after handling TAG_VENDOR_SPECIFIC, so vendor-specific PADR tags (e.g., TR-101) no longer fall through and get misinterpreted as other tags like TAG_PPP_MAX_PAYLOAD.