### PR TITLE
Suppress OpenSSL 3.0 deprecation warnings for legacy crypto APIs

### DIFF
--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -20,8 +20,13 @@
 #include "linux_ppp.h"
 
 #ifdef CRYPTO_OPENSSL
+/*
+ * Suppress OpenSSL 3.0 deprecation warnings for DH API.
+ * See crypto.h for detailed explanation.
+ */
+#define OPENSSL_API_COMPAT 0x10100000L
 #include <openssl/ssl.h>
-#include <openssl/err.h> 
+#include <openssl/err.h>
 #endif
 
 #include "triton.h"

--- a/accel-pppd/radius/packet.c
+++ b/accel-pppd/radius/packet.c
@@ -8,6 +8,12 @@
 #include <sys/mman.h>
 #include <linux/mman.h>
 #include <arpa/inet.h>
+
+/*
+ * Suppress OpenSSL 3.0 deprecation warnings for HMAC API.
+ * See crypto.h for detailed explanation.
+ */
+#define OPENSSL_API_COMPAT 0x10100000L
 #include <openssl/hmac.h>
 #include <openssl/evp.h>
 

--- a/crypto/crypto.h
+++ b/crypto/crypto.h
@@ -3,6 +3,20 @@
 
 #ifdef CRYPTO_OPENSSL
 
+/*
+ * Suppress OpenSSL 3.0 deprecation warnings for legacy crypto APIs.
+ * These low-level APIs (MD5, SHA1, DES, etc.) are deprecated in OpenSSL 3.0
+ * but still functional and required for protocol compatibility.
+ *
+ * This approach is consistent with other major projects:
+ * - FreeRADIUS: Uses OPENSSL_API_COMPAT for the same reason
+ * - OpenVPN: Uses OPENSSL_API_COMPAT to maintain legacy protocol support
+ *
+ * The deprecated functions will remain available in OpenSSL 3.x series.
+ * Migration to EVP API may be considered for future major versions.
+ */
+#define OPENSSL_API_COMPAT 0x10100000L
+
 #include <openssl/md4.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>


### PR DESCRIPTION
We are using similar approach as in other projects, easiest one, but probably in future it will break as soon as this functions will be removed completely.