### PR TITLE
fixup! Add RADIUS blast attack protection with Message-Authenticator

### DIFF
--- a/accel-pppd/radius/packet.c
+++ b/accel-pppd/radius/packet.c
@@ -852,7 +852,7 @@ int rad_packet_send(struct rad_packet_t *pack, int fd, struct sockaddr_in *addr)
 		uint8_t hmac[HMAC_MD5_LEN];
 		uint8_t *ptr = pack->buf;
 		uint8_t *hmac_ptr = ptr + PACKET_SIGNED_OFFSET;
-		if (hmac_md5((const uint8_t *)pack->secret, strlen(pack->secret), pack->buf, pack->len, hmac) < 0) {
+		if (hmac_md5((const uint8_t *)pack->secret, strlen((const char *)pack->secret), pack->buf, pack->len, hmac) < 0) {
 			log_emerg("radius:packet: failed to calculate HMAC\n");
 			return -1;
 		}

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -78,10 +78,10 @@ static struct rad_req_t *__rad_req_alloc(struct radius_pd_t *rpd, int code, cons
 	if (code == CODE_ACCESS_REQUEST && conf_blast_protection) {
 		uint8_t buf[HMAC_MD5_LEN] = {0};
 		req->pack->message_authenticator = 1;
-		req->pack->secret = strdup(req->serv->secret);
+		req->pack->secret = (uint8_t *)strdup(req->serv->secret);
 		if (rad_packet_add_octets(req->pack, NULL, "Message-Authenticator", buf, HMAC_MD5_LEN)) {
-                        free(req->pack->secret);
-                        req->pack->secret == NULL;
+			free(req->pack->secret);
+			req->pack->secret = NULL;
 			goto out_err;
                 }
 	}


### PR DESCRIPTION
Not a bug, but to supress warnings.