### PR TITLE
cli: log streaming + optional in-memory tail buffer

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -150,6 +150,7 @@ ADD_EXECUTABLE(accel-pppd
 
 	cli/std_cmd.c
 	cli/show_sessions.c
+	cli/log_stream.c
 	cli/telnet.c
 	cli/tcp.c
 	cli/cli.c
@@ -199,4 +200,3 @@ IF (NOT DEFINED CPACK_TYPE)
 	INSTALL(DIRECTORY DESTINATION "${CMAKE_INSTALL_LOCALSTATEDIR}/log/accel-ppp")
 	INSTALL(DIRECTORY DESTINATION "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/accel-ppp")
 ENDIF (NOT DEFINED CPACK_TYPE)
-

--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -303,6 +303,7 @@ verbose=1
 telnet=127.0.0.1:2000
 tcp=127.0.0.1:2001
 #password=123
+#log-history=0
 #sessions-columns=ifname,username,ip,ip6,ip6-dp,type,state,uptime,uptime-raw,calling-sid,called-sid,sid,comp,inbound-if,service-name,rx-bytes,tx-bytes,rx-bytes-raw,tx-bytes-raw,rx-pkts,tx-pkts,netns,vrf
 
 [snmp]

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -1383,6 +1383,9 @@ to \fIaccel-ppp\fR).
 Defines the file used by the Telnet module for loading and storing its
 command history (defaults to \fI/var/lib/accel-ppp/history\fR).
 .TP
+.BI "log-history=" n
+Number of recent log lines to keep in memory for the CLI "log show" / "log follow tail" commands (0 disables the buffer, which is the default; maximum is 5000).
+.TP
 .BI "sessions-columns=" column_list
 Defines the default set of columns to be displayed by the "show sessions"
 command (defaults to

--- a/accel-pppd/cli/cli_p.h
+++ b/accel-pppd/cli/cli_p.h
@@ -2,6 +2,7 @@
 #define __CLI_P_H
 
 #include <stdarg.h>
+#include <stddef.h>
 
 #include "triton.h"
 
@@ -11,12 +12,19 @@ struct cli_client_t
 	int (*send)(struct cli_client_t *, const void *buf, int size);
 	int (*sendv)(struct cli_client_t *, const char *fmt, va_list ap);
 	void (*disconnect)(struct cli_client_t *);
+	/* triton context serving this client's I/O; all sends must be
+	 * serialized in it (log_stream delivers via triton_context_call) */
+	struct triton_context_t *ctx;
+	/* bytes pending in the transmit queue, maintained by the
+	 * transport, accessed only from ctx */
+	size_t queued_bytes;
 };
 
 int cli_process_cmd(struct cli_client_t *cln);
+
+void cli_log_stream_on_disconnect(struct cli_client_t *cln);
 
 extern char *conf_cli_passwd;
 extern char *conf_cli_prompt;
 
 #endif
-

--- a/accel-pppd/cli/log_stream.c
+++ b/accel-pppd/cli/log_stream.c
@@ -1,0 +1,648 @@
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <limits.h>
+
+#include "triton.h"
+#include "cli.h"
+#include "cli_p.h"
+#include "list.h"
+#include "log.h"
+#include "events.h"
+#include "ppp.h"
+#include "utils.h"
+
+#include "memdebug.h"
+
+#define CLI_LOG_LEVEL_MIN 0
+#define CLI_LOG_LEVEL_MAX 5
+#define CLI_LOG_LEVEL_DEFAULT 5
+
+#define CLI_LOG_HISTORY_DEFAULT 0
+#define CLI_LOG_HISTORY_MAX 5000
+
+/* max lines queued per subscriber awaiting delivery in its context */
+#define CLI_LOG_PENDING_MAX 256
+/* max bytes sitting in the client transmit queue before the
+ * subscription is dropped (slow consumer protection) */
+#define CLI_LOG_BACKLOG_MAX (1 << 20)
+
+struct cli_log_line_t
+{
+	struct list_head entry;
+	char buf[0];
+};
+
+/* All fields are protected by subs_lock. sub->client is dereferenced
+ * only from the client's own triton context (sub->ctx) and only while
+ * !dead: the transports mark the subscription dead (via
+ * cli_log_stream_on_disconnect) in that same context before freeing
+ * the client, so the pointer cannot go stale under a flush. */
+struct cli_log_sub_t
+{
+	struct list_head entry;
+	struct cli_client_t *client;
+	struct triton_context_t *ctx;
+	int max_level;
+	int ref_cnt;
+	struct list_head pending;
+	int pending_cnt;
+	unsigned int queued:1;
+	unsigned int overrun:1;
+	unsigned int dead:1;
+};
+
+static pthread_mutex_t subs_lock = PTHREAD_MUTEX_INITIALIZER;
+static LIST_HEAD(subs);
+static int subs_count;
+
+static pthread_mutex_t history_lock = PTHREAD_MUTEX_INITIALIZER;
+static char **history;
+static int history_max = CLI_LOG_HISTORY_DEFAULT;
+static int history_len;
+static int history_pos;
+static int history_enabled;
+static int initialized = 0;
+
+static void history_resize(int n)
+{
+	int i;
+
+	if (n < 0)
+		n = 0;
+	else if (n > CLI_LOG_HISTORY_MAX)
+		n = CLI_LOG_HISTORY_MAX;
+
+	pthread_mutex_lock(&history_lock);
+
+	if (history && n == history_max) {
+		pthread_mutex_unlock(&history_lock);
+		return;
+	}
+
+	if (history) {
+		for (i = 0; i < history_max; i++)
+			if (history[i])
+				_free(history[i]);
+		_free(history);
+		history = NULL;
+	}
+
+	history_max = n;
+	history_len = 0;
+	history_pos = 0;
+
+	if (history_max > 0)
+		history = _malloc(sizeof(*history) * history_max);
+
+	if (history)
+		memset(history, 0, sizeof(*history) * history_max);
+	else
+		history_max = 0;
+
+	__sync_lock_test_and_set(&history_enabled, history_max > 0);
+
+	pthread_mutex_unlock(&history_lock);
+}
+
+static void history_add(const char *line)
+{
+	char *dup;
+
+	pthread_mutex_lock(&history_lock);
+
+	if (!history || history_max <= 0) {
+		pthread_mutex_unlock(&history_lock);
+		return;
+	}
+
+	dup = _strdup(line);
+	if (!dup) {
+		pthread_mutex_unlock(&history_lock);
+		return;
+	}
+
+	if (history[history_pos])
+		_free(history[history_pos]);
+
+	history[history_pos] = dup;
+
+	history_pos = (history_pos + 1) % history_max;
+	if (history_len < history_max)
+		history_len++;
+
+	pthread_mutex_unlock(&history_lock);
+}
+
+/* Runs in the client's own context. Snapshots the lines under
+ * history_lock and sends after releasing it: cli_send() may log on
+ * error and the recursive history_add() would deadlock on
+ * history_lock if it was still held here. */
+static void history_send_tail(struct cli_client_t *client, int tail)
+{
+	char **snap;
+	int i;
+	int start;
+	int count = 0;
+	int failed = 0;
+
+	if (tail <= 0)
+		return;
+
+	pthread_mutex_lock(&history_lock);
+
+	if (!history || history_len == 0) {
+		pthread_mutex_unlock(&history_lock);
+		return;
+	}
+
+	if (tail > history_len)
+		tail = history_len;
+
+	snap = _malloc(sizeof(*snap) * tail);
+	if (!snap) {
+		pthread_mutex_unlock(&history_lock);
+		return;
+	}
+
+	start = history_pos - tail;
+	if (start < 0)
+		start += history_max;
+
+	for (i = 0; i < tail; i++) {
+		const char *line = history[(start + i) % history_max];
+		if (!line)
+			continue;
+		snap[count] = _strdup(line);
+		if (snap[count])
+			count++;
+	}
+
+	pthread_mutex_unlock(&history_lock);
+
+	for (i = 0; i < count; i++) {
+		if (!failed && cli_send(client, snap[i]) < 0)
+			failed = 1;
+		_free(snap[i]);
+	}
+
+	_free(snap);
+}
+
+/* Requires subs_lock to be held */
+static inline struct cli_log_sub_t *sub_find(struct cli_client_t *client)
+{
+	struct cli_log_sub_t *sub;
+
+	list_for_each_entry(sub, &subs, entry)
+		if (sub->client == client)
+			return sub;
+
+	return NULL;
+}
+
+static void sub_free(struct cli_log_sub_t *sub)
+{
+	struct cli_log_line_t *l;
+
+	while (!list_empty(&sub->pending)) {
+		l = list_entry(sub->pending.next, typeof(*l), entry);
+		list_del(&l->entry);
+		_free(l);
+	}
+
+	_free(sub);
+}
+
+/* Requires subs_lock to be held. Unlinks the subscription from the
+ * subscriber list; the sub itself is freed when the last reference
+ * (list or in-flight flush) is dropped. */
+static void sub_detach(struct cli_log_sub_t *sub)
+{
+	list_del(&sub->entry);
+	sub->dead = 1;
+	sub->client = NULL;
+	__sync_sub_and_fetch(&subs_count, 1);
+
+	sub->ref_cnt--;
+	if (sub->ref_cnt == 0)
+		sub_free(sub);
+}
+
+static void sub_remove_client(struct cli_client_t *client)
+{
+	struct list_head *pos, *n;
+	struct cli_log_sub_t *sub;
+
+	pthread_mutex_lock(&subs_lock);
+	list_for_each_safe(pos, n, &subs) {
+		sub = list_entry(pos, typeof(*sub), entry);
+		if (sub->client == client)
+			sub_detach(sub);
+	}
+	pthread_mutex_unlock(&subs_lock);
+}
+
+void cli_log_stream_on_disconnect(struct cli_client_t *cln)
+{
+	sub_remove_client(cln);
+}
+
+/* Runs in the subscriber's own triton context (scheduled with
+ * triton_context_call()), so cli_send() here is serialized with the
+ * rest of the client's I/O. No locks are held while sending. */
+static void sub_flush(void *arg)
+{
+	struct cli_log_sub_t *sub = arg;
+	struct cli_client_t *client;
+	struct cli_log_line_t *l;
+	LIST_HEAD(lines);
+	int overrun;
+	int failed = 0;
+
+	pthread_mutex_lock(&subs_lock);
+	sub->queued = 0;
+	list_splice_init(&sub->pending, &lines);
+	sub->pending_cnt = 0;
+	overrun = sub->overrun;
+	sub->overrun = 0;
+	client = sub->dead ? NULL : sub->client;
+	pthread_mutex_unlock(&subs_lock);
+
+	while (!list_empty(&lines)) {
+		l = list_entry(lines.next, typeof(*l), entry);
+		list_del(&l->entry);
+		if (client && !failed && cli_send(client, l->buf) < 0)
+			failed = 1;
+		_free(l);
+	}
+
+	if (client && !failed && overrun) {
+		if (cli_send(client, "log follow: overrun, some lines were dropped\r\n") < 0)
+			failed = 1;
+	}
+
+	if (client && !failed && client->queued_bytes > CLI_LOG_BACKLOG_MAX) {
+		cli_send(client, "log follow: client is too slow, disabling\r\n");
+		failed = 1;
+	}
+
+	pthread_mutex_lock(&subs_lock);
+	if (failed && !sub->dead)
+		sub_detach(sub);
+	sub->ref_cnt--;
+	if (sub->ref_cnt == 0)
+		sub_free(sub);
+	pthread_mutex_unlock(&subs_lock);
+}
+
+static int sub_set(struct cli_client_t *client, int max_level)
+{
+	struct cli_log_sub_t *sub;
+
+	if (!client->ctx)
+		return -1;
+
+	if (max_level < CLI_LOG_LEVEL_MIN)
+		max_level = CLI_LOG_LEVEL_MIN;
+	else if (max_level > CLI_LOG_LEVEL_MAX)
+		max_level = CLI_LOG_LEVEL_MAX;
+
+	pthread_mutex_lock(&subs_lock);
+
+	sub = sub_find(client);
+	if (sub) {
+		sub->max_level = max_level;
+		pthread_mutex_unlock(&subs_lock);
+		return 0;
+	}
+
+	sub = _malloc(sizeof(*sub));
+	if (!sub) {
+		pthread_mutex_unlock(&subs_lock);
+		return -1;
+	}
+	memset(sub, 0, sizeof(*sub));
+	sub->client = client;
+	sub->ctx = client->ctx;
+	sub->max_level = max_level;
+	sub->ref_cnt = 1;
+	INIT_LIST_HEAD(&sub->pending);
+	list_add_tail(&sub->entry, &subs);
+	__sync_add_and_fetch(&subs_count, 1);
+
+	pthread_mutex_unlock(&subs_lock);
+	return 0;
+}
+
+static void sub_unset(struct cli_client_t *client)
+{
+	sub_remove_client(client);
+}
+
+static void format_msg(char *out, size_t out_size, struct log_msg_t *msg, struct ap_session *ses)
+{
+	struct log_chunk_t *chunk;
+	struct tm tm;
+	int pos = 0;
+	int n;
+
+	if (!out_size)
+		return;
+
+	localtime_r(&msg->timestamp.tv_sec, &tm);
+
+	n = snprintf(out + pos, out_size - pos,
+		"[%04i-%02i-%02i %02i:%02i:%02i.%03i] ",
+		tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+		tm.tm_hour, tm.tm_min, tm.tm_sec,
+		(int)msg->timestamp.tv_usec / 1000);
+
+	if (n >= 0) {
+		if ((size_t)n >= out_size - pos)
+			pos = out_size - 1;
+		else
+			pos += n;
+	}
+
+	if (ses) {
+		const char *ifname = ses->ifname[0] ? ses->ifname : ses->ctrl->ifname;
+		const char *ident = ses->username ? ses->username : ses->sessionid;
+		n = snprintf(out + pos, out_size - pos, "%s: %s: ", ifname, ident);
+
+		if (n >= 0) {
+			if ((size_t)n >= out_size - pos)
+				pos = out_size - 1;
+			else
+				pos += n;
+		}
+	}
+
+	list_for_each_entry(chunk, msg->chunks, entry) {
+		int i;
+		for (i = 0; i < chunk->len && pos + 2 < (int)out_size; i++) {
+			char c = chunk->msg[i];
+			if (c == '\n') {
+				out[pos++] = '\r';
+				out[pos++] = '\n';
+			} else
+				out[pos++] = c;
+		}
+		if (pos + 2 >= (int)out_size)
+			break;
+	}
+
+	if (pos >= 2 && out[pos - 2] == '\r' && out[pos - 1] == '\n') {
+		out[pos] = '\0';
+		return;
+	}
+
+	if (pos + 2 < (int)out_size) {
+		out[pos++] = '\r';
+		out[pos++] = '\n';
+	}
+
+	out[pos] = '\0';
+}
+
+/* Called synchronously from whatever thread emitted the log message.
+ * Never sends to clients from here: lines are queued per subscriber
+ * and delivered by sub_flush() in the client's own context. This also
+ * makes recursive logging safe (e.g. cli_send() failing and calling
+ * log_error()): this function only takes subs_lock/history_lock and
+ * never calls back into the CLI transports. */
+static void cli_log_target_log(struct log_target_t *t, struct log_msg_t *msg, struct ap_session *ses)
+{
+	char buf[LOG_MAX_SIZE * 2 + 512];
+	struct cli_log_sub_t *sub;
+	size_t len;
+
+	(void)t;
+
+	/* lockless fast path; the race with (un)subscribe is benign:
+	 * at worst one line is dropped around the transition */
+	if (!__sync_fetch_and_add(&subs_count, 0) && !__sync_fetch_and_add(&history_enabled, 0)) {
+		log_free_msg(msg);
+		return;
+	}
+
+	format_msg(buf, sizeof(buf), msg, ses);
+	history_add(buf);
+
+	len = strlen(buf);
+
+	pthread_mutex_lock(&subs_lock);
+	list_for_each_entry(sub, &subs, entry) {
+		struct cli_log_line_t *l;
+
+		if (msg->level > sub->max_level)
+			continue;
+
+		if (sub->pending_cnt >= CLI_LOG_PENDING_MAX) {
+			sub->overrun = 1;
+		} else {
+			l = _malloc(sizeof(*l) + len + 1);
+			if (!l) {
+				sub->overrun = 1;
+			} else {
+				memcpy(l->buf, buf, len + 1);
+				list_add_tail(&l->entry, &sub->pending);
+				sub->pending_cnt++;
+			}
+		}
+
+		if (!sub->queued) {
+			sub->queued = 1;
+			sub->ref_cnt++;
+			if (triton_context_call(sub->ctx, sub_flush, sub)) {
+				sub->queued = 0;
+				sub->ref_cnt--;
+			}
+		}
+	}
+	pthread_mutex_unlock(&subs_lock);
+
+	log_free_msg(msg);
+}
+
+static struct log_target_t cli_log_target = {
+	.log = cli_log_target_log,
+};
+
+static void cli_log_follow_help(char * const *fields, int fields_cnt, void *client)
+{
+	(void)fields;
+	(void)fields_cnt;
+	cli_send(client, "log follow [level <0..5>] [tail <n>] - stream logs to this CLI client\r\n");
+}
+
+static int cli_log_follow_exec(const char *cmd, char * const *fields, int fields_cnt, void *client)
+{
+	int i;
+	int max_level = CLI_LOG_LEVEL_DEFAULT;
+	int tail = 0;
+	struct cli_client_t *cln = (struct cli_client_t *)client;
+	long int val;
+
+	(void)cmd;
+
+	for (i = 2; i < fields_cnt; ) {
+		if (!strcmp(fields[i], "level") && i + 1 < fields_cnt) {
+			if (u_readlong(&val, fields[i + 1], CLI_LOG_LEVEL_MIN, CLI_LOG_LEVEL_MAX))
+				return CLI_CMD_SYNTAX;
+			max_level = (int)val;
+			i += 2;
+			continue;
+		}
+		if (!strcmp(fields[i], "tail") && i + 1 < fields_cnt) {
+			if (u_readlong(&val, fields[i + 1], 0, INT_MAX))
+				return CLI_CMD_SYNTAX;
+			tail = (int)val;
+			i += 2;
+			continue;
+		}
+		return CLI_CMD_SYNTAX;
+	}
+
+	if (tail > 0) {
+		if (__sync_fetch_and_add(&history_enabled, 0))
+			history_send_tail(cln, tail);
+		else
+			cli_send(client, "log follow: history disabled, tail unavailable (see 'log history')\r\n");
+	}
+
+	if (sub_set(cln, max_level)) {
+		cli_send(client, "log follow: not supported on this connection\r\n");
+		return CLI_CMD_FAILED;
+	}
+
+	cli_send(client, "log follow: enabled\r\n");
+	return CLI_CMD_OK;
+}
+
+static void cli_log_stop_help(char * const *fields, int fields_cnt, void *client)
+{
+	(void)fields;
+	(void)fields_cnt;
+	cli_send(client, "log stop - stop streaming logs to this CLI client\r\n");
+}
+
+static int cli_log_stop_exec(const char *cmd, char * const *fields, int fields_cnt, void *client)
+{
+	struct cli_client_t *cln = (struct cli_client_t *)client;
+
+	(void)cmd;
+	(void)fields;
+
+	if (fields_cnt != 2)
+		return CLI_CMD_SYNTAX;
+
+	sub_unset(cln);
+	cli_send(client, "log follow: disabled\r\n");
+	return CLI_CMD_OK;
+}
+
+static void cli_show_log_help(char * const *fields, int fields_cnt, void *client)
+{
+	(void)fields;
+	(void)fields_cnt;
+	cli_send(client, "log show [n] - show last N log lines seen by accel-pppd (default 50)\r\n");
+}
+
+static int cli_show_log_exec(const char *cmd, char * const *fields, int fields_cnt, void *client)
+{
+	int tail = 50;
+	struct cli_client_t *cln = (struct cli_client_t *)client;
+	long int val;
+
+	(void)cmd;
+
+	if (fields_cnt == 3) {
+		if (u_readlong(&val, fields[2], 0, INT_MAX))
+			return CLI_CMD_SYNTAX;
+		tail = (int)val;
+	} else if (fields_cnt != 2)
+		return CLI_CMD_SYNTAX;
+
+	if (!__sync_fetch_and_add(&history_enabled, 0)) {
+		cli_send(client, "log show: history disabled, enable with 'log history <n>' or [cli] log-history\r\n");
+		return CLI_CMD_OK;
+	}
+
+	history_send_tail(cln, tail);
+	return CLI_CMD_OK;
+}
+
+static void cli_log_history_help(char * const *fields, int fields_cnt, void *client)
+{
+	(void)fields;
+	(void)fields_cnt;
+	cli_send(client, "log history [n] - show/set CLI log buffer size (0 disables, max 5000)\r\n");
+}
+
+static int cli_log_history_exec(const char *cmd, char * const *fields, int fields_cnt, void *client)
+{
+	int n;
+	long int val;
+
+	(void)cmd;
+
+	if (fields_cnt == 2) {
+		cli_sendv(client, "log history: %d\r\n", history_max);
+		return CLI_CMD_OK;
+	}
+
+	if (fields_cnt != 3)
+		return CLI_CMD_SYNTAX;
+
+	if (!strcmp(fields[2], "off"))
+		n = 0;
+	else {
+		if (u_readlong(&val, fields[2], 0, INT_MAX))
+			return CLI_CMD_SYNTAX;
+		n = (int)val;
+	}
+
+	history_resize(n);
+	cli_sendv(client, "log history: %d\r\n", history_max);
+	return CLI_CMD_OK;
+}
+
+static void load_config(void)
+{
+	const char *opt;
+	int n;
+	long int val;
+
+	opt = conf_get_opt("cli", "log-history");
+	if (opt && !u_readlong(&val, opt, 0, INT_MAX))
+		n = (int)val;
+	else
+		n = CLI_LOG_HISTORY_DEFAULT;
+	history_resize(n);
+}
+
+static void init(void)
+{
+	load_config();
+
+	log_register_target(&cli_log_target);
+
+	cli_register_simple_cmd2(cli_log_follow_exec, cli_log_follow_help, 2, "log", "follow");
+	cli_register_simple_cmd2(cli_log_stop_exec, cli_log_stop_help, 2, "log", "stop");
+	cli_register_simple_cmd2(cli_show_log_exec, cli_show_log_help, 2, "log", "show");
+	cli_register_simple_cmd2(cli_log_history_exec, cli_log_history_help, 2, "log", "history");
+
+	triton_event_register_handler(EV_CONFIG_RELOAD, (triton_event_func)load_config);
+	initialized = 1;
+}
+
+DEFINE_INIT(2, init);
+
+static void __exit cleanup(void)
+{
+	if (initialized)
+		log_unregister_target(&cli_log_target);
+}

--- a/accel-pppd/cli/tcp.c
+++ b/accel-pppd/cli/tcp.c
@@ -54,6 +54,8 @@ static void disconnect(struct tcp_client_t *cln)
 
 	log_debug("cli: disconnect\n");
 
+	cli_log_stream_on_disconnect(&cln->cli_client);
+
 	list_del(&cln->entry);
 
 	triton_md_unregister_handler(&cln->hnd, 1);
@@ -79,6 +81,8 @@ static void cli_client_disconnect(struct cli_client_t *tcln)
 
 static void queue_buffer(struct tcp_client_t *cln, struct buffer_t *b)
 {
+	cln->cli_client.queued_bytes += b->size;
+
 	if (cln->xmit_buf)
 		list_add_tail(&b->entry, &cln->xmit_queue);
 	else
@@ -220,6 +224,7 @@ static int cln_write(struct triton_md_handler_t *h)
 			}
 		}
 
+		cln->cli_client.queued_bytes -= cln->xmit_buf->size;
 		_free(cln->xmit_buf);
 		cln->xmit_pos = 0;
 
@@ -284,6 +289,7 @@ static int serv_read(struct triton_md_handler_t *h)
 		conn->cli_client.send = cli_client_send;
 		conn->cli_client.sendv = cli_client_sendv;
 		conn->cli_client.disconnect = cli_client_disconnect;
+		conn->cli_client.ctx = &serv_ctx;
 
 		triton_md_register_handler(&serv_ctx, &conn->hnd);
 		triton_md_enable_handler(&conn->hnd,MD_MODE_READ);

--- a/accel-pppd/cli/telnet.c
+++ b/accel-pppd/cli/telnet.c
@@ -83,6 +83,8 @@ static void disconnect(struct telnet_client_t *cln)
 
 	log_debug("cli: disconnect\n");
 
+	cli_log_stream_on_disconnect(&cln->cli_client);
+
 	triton_stop_collect_cpu_usage();
 
 	list_del(&cln->entry);
@@ -128,6 +130,8 @@ static void cli_client_disconnect(struct cli_client_t *tcln)
 
 static void queue_buffer(struct telnet_client_t *cln, struct buffer_t *b)
 {
+	cln->cli_client.queued_bytes += b->size;
+
 	if (cln->xmit_buf)
 		list_add_tail(&b->entry, &cln->xmit_queue);
 	else
@@ -528,6 +532,7 @@ static int cln_write(struct triton_md_handler_t *h)
 			}
 		}
 
+		cln->cli_client.queued_bytes -= cln->xmit_buf->size;
 		_free(cln->xmit_buf);
 		cln->xmit_pos = 0;
 
@@ -607,6 +612,7 @@ static int serv_read(struct triton_md_handler_t *h)
 		conn->cli_client.send = cli_client_send;
 		conn->cli_client.sendv = cli_client_sendv;
 		conn->cli_client.disconnect = cli_client_disconnect;
+		conn->cli_client.ctx = &serv_ctx;
 
 		triton_md_register_handler(&serv_ctx, &conn->hnd);
 		triton_md_enable_handler(&conn->hnd,MD_MODE_READ);

--- a/accel-pppd/log.c
+++ b/accel-pppd/log.c
@@ -96,7 +96,8 @@ static void do_log(int level, const char *fmt, va_list ap, struct ap_session *se
 	if (add_msg(cur_msg, stat_buf))
 		goto out;
 
-	if (stat_buf[strlen(stat_buf) - 1] != '\n')
+	size_t len = strlen(stat_buf);
+	if (len == 0 || stat_buf[len - 1] != '\n')
 		return;
 
 	if (debug_file)
@@ -477,6 +478,14 @@ void __export log_switch(struct triton_context_t *ctx, void *arg)
 void __export log_register_target(struct log_target_t *t)
 {
 	list_add_tail(&t->entry, &targets);
+}
+
+/* The targets list is iterated without locking by all logging
+ * threads, so this is only safe to call during shutdown when no more
+ * log messages are being emitted. */
+void __export log_unregister_target(struct log_target_t *t)
+{
+	list_del(&t->entry);
 }
 
 static void sighup(int n)

--- a/accel-pppd/log.h
+++ b/accel-pppd/log.h
@@ -58,5 +58,6 @@ void log_ppp_msg(const char *fmt, ...) __attribute__((format(gnu_printf, 1, 2)))
 void log_switch(struct triton_context_t *ctx, void *arg);
 
 void log_register_target(struct log_target_t *t);
+void log_unregister_target(struct log_target_t *t);
 
 #endif

--- a/docs/logs_streaming.md
+++ b/docs/logs_streaming.md
@@ -1,0 +1,53 @@
+# CLI log streaming
+
+accel-pppd can stream its current logs to an interactive CLI client session.
+
+## Commands
+
+- `log show [n]` prints the last N buffered log lines (default: 50).
+- `log follow [level <0..5>] [tail <n>]` starts streaming new log lines to the current CLI client.
+  - `level` filters by log level (0..5). Higher is more verbose.
+  - `tail` prints the last N buffered lines before starting the live stream.
+- `log stop` stops streaming for the current CLI client.
+
+## Examples
+
+Using `accel-cmd`:
+
+```sh
+accel-cmd log show 50
+accel-cmd log follow tail 200 level 3
+accel-cmd log stop
+```
+
+## Configuration
+
+In `accel-ppp.conf`:
+
+```ini
+[cli]
+# Number of recent log lines kept in memory for `log show` / `log follow tail`.
+# Set to 0 to disable buffering.
+log-history=0
+```
+
+You can also change it at runtime via CLI (clears current buffer):
+
+```sh
+accel-cmd log history 200
+accel-cmd log history 0
+```
+
+## Delivery and overload behavior
+
+Log lines are queued per subscriber and delivered asynchronously in the
+client's own I/O context, so streaming never blocks or interferes with the
+threads emitting log messages.
+
+- If a subscriber cannot keep up, queued lines are dropped and a single
+  `log follow: overrun, some lines were dropped` notice is printed.
+- If the client's transmit backlog keeps growing (a stalled reader), the
+  subscription is dropped with `log follow: client is too slow, disabling`
+  to protect the daemon's memory.
+- Lines emitted between the `tail` replay and the start of the live stream
+  may be missed; `tail` replay requires the history buffer to be enabled.

--- a/tests/accel-cmd/test_log_streaming.py
+++ b/tests/accel-cmd/test_log_streaming.py
@@ -1,0 +1,68 @@
+from subprocess import PIPE, Popen, TimeoutExpired
+
+import pytest
+from common import process
+
+
+@pytest.fixture()
+def accel_pppd_config():
+    return """
+    [modules]
+
+    [log]
+    log-debug=/dev/stdout
+    level=5
+
+    [cli]
+    tcp=127.0.0.1:2001
+    log-history=10
+    verbose=2
+    """
+
+
+def test_log_history_command(accel_pppd_instance, accel_cmd):
+    assert accel_pppd_instance
+
+    (exit_hist, out_hist, err_hist) = process.run([accel_cmd, "log history"])
+    assert exit_hist == 0 and "log history: 10" in out_hist and err_hist == ""
+
+    (exit_set, out_set, err_set) = process.run([accel_cmd, "log history 5"])
+    assert exit_set == 0 and "log history: 5" in out_set and err_set == ""
+
+    (exit_off, out_off, err_off) = process.run([accel_cmd, "log history off"])
+    assert exit_off == 0 and "log history: 0" in out_off and err_off == ""
+
+
+def test_log_show_and_follow(accel_pppd_instance, accel_cmd):
+    assert accel_pppd_instance
+
+    (exit_hist, out_hist, err_hist) = process.run([accel_cmd, "log history 10"])
+    assert exit_hist == 0 and "log history: 10" in out_hist and err_hist == ""
+
+    (exit_stat, out_stat, err_stat) = process.run([accel_cmd, "show stat"])
+    assert exit_stat == 0 and "uptime" in out_stat and err_stat == ""
+
+    (exit_show, out_show, err_show) = process.run([accel_cmd, "log show 5"])
+    assert exit_show == 0 and err_show == "" and "show stat" in out_show
+
+    proc = Popen([accel_cmd], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    try:
+        out_follow, err_follow = proc.communicate(
+            input=b"log follow tail 1\nlog stop\n",
+            timeout=5,
+        )
+    except TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        pytest.fail("accel-cmd log follow did not exit")
+
+    out_follow = out_follow.decode("utf-8")
+    err_follow = err_follow.decode("utf-8")
+
+    assert (
+        proc.returncode == 0
+        and err_follow == ""
+        and "log follow: enabled" in out_follow
+        and "log follow: disabled" in out_follow
+        and "cli:" in out_follow
+    )


### PR DESCRIPTION
Adds a CLI log streaming feature to accel-pppd.
New comands:

- log follow [level <0..5>] [tail <n>] to stream live daemon logs to the current CLI client, optionally replaying the last N buffered lines.
- log stop to stop streaming for the current client.
- log show [n] to print the last N buffered lines.
- log history [n|off] to view/set the in-memory log buffer size at runtime (0 disables, max 5000; changing it clears the buffer).

The in-memory buffer (cli log-history) now defaults to 0 (disabled) to avoid overhead on busy systems; when both log-history=0 and there are no log follow subscribers, the log target drops messages with near-zero extra work. Streaming subscriptions are cleaned up on client disconnect.