### PR TITLE
Add support for L4-Redirect using nftables sets.

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -104,6 +104,7 @@ ENDIF (SHAPER)
 
 INCLUDE(CheckIncludeFile)
 CHECK_INCLUDE_FILE("linux/netfilter/ipset/ip_set.h" HAVE_IPSET)
+CHECK_INCLUDE_FILE("linux/netfilter/nf_tables.h" HAVE_NFTABLES)
 # MUSL does not have printf.h
 CHECK_INCLUDE_FILE("printf.h" HAVE_PRINTF_H)
 IF (HAVE_PRINTF_H)
@@ -158,6 +159,7 @@ ADD_EXECUTABLE(accel-pppd
 	libnetlink/iputils.c
 	libnetlink/genl.c
 	libnetlink/ipset.c
+	libnetlink/nftables_set.c
 
 	pwdb.c
 	ipdb.c

--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -157,6 +157,7 @@ max-lease-time=3600
 #unit-cache=1000
 #l4-redirect-table=4
 #l4-redirect-ipset=l4
+#l4-redirect-nftables=family=ip,table=filter,set=l4set
 #l4-redirect-on-reject=300
 #l4-redirect-ip-pool=pool1
 shared=0
@@ -183,6 +184,7 @@ start=dhcpv4
 #attr-l4-redirect=L4-Redirect
 #attr-l4-redirect-table=4
 #attr-l4-redirect-ipset=l4-redirect
+#attr-l4-redirect-nftables=l4-redirect
 #lua-file=/etc/accel-ppp.lua
 #offer-delay=0,100:100,200:200,-1:1000
 #vlan-mon=eth0,10-200

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -353,6 +353,13 @@ Specifies number of table. If L4-Redirect radius attribute is received and it's 
 .BI "l4-redirect-ipset=" name
 Specifies name of ipset list. If L4-Redirect radius attribute is received and it's value is not 0 or '0' then accel-ppp will add client's ip to that ipset name.
 .TP
+.BI "l4-redirect-nftables=" family=<ip|inet>,table=<table name>,set=<set name>
+Specifies the nftables configuration for L4-Redirect. All three fields are required and must match an existing set in your nftables rules:
+- \fIfamily\fR: Either "ip" (IPv4) or "inet" (IPv4+IPv6).  
+- \fitable\fR: Name of the nftables table containing the set.  
+- \fiset\fR: Name of the nftables set to which client's IPv4 will be added.
+If a L4-Redirect RADIUS is received with a non-zero value, accel-ppp will automatically add the client’s IPv4 address to the specified nftables set.
+.TP
 .BI "l4-redirect-on-reject=" n
 If specified then if radius rejects access 'ip rule add from ip_addr table l4-redirect-table' rule will be created for time
 .B n

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -96,6 +96,7 @@ struct ipoe_session {
 	uint32_t relay_server_id;
 	int l4_redirect_table;
 	char *l4_redirect_ipset;
+	char *l4_redirect_nftables;
 	int mask;
 	int lease_time;
 	int renew_time;

--- a/accel-pppd/include/nftables_set.h
+++ b/accel-pppd/include/nftables_set.h
@@ -1,0 +1,1 @@
+../libnetlink/nftables_set.h

--- a/accel-pppd/libnetlink/libnetlink.h
+++ b/accel-pppd/libnetlink/libnetlink.h
@@ -2,7 +2,7 @@
 #define __LIBNETLINK_H__ 1
 
 #include <asm/types.h>
-#include <linux/netlink.h>
+#include <linux/netlink.h> 
 #include <linux/rtnetlink.h>
 #include <linux/if_link.h>
 #include <linux/if_addr.h>
@@ -67,6 +67,10 @@ extern int rta_addattr_l(struct rtattr *rta, int maxlen, int type, const void *d
 extern int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len);
 extern int parse_rtattr_byindex(struct rtattr *tb[], int max, struct rtattr *rta, int len);
 extern int __parse_rtattr_nested_compat(struct rtattr *tb[], int max, struct rtattr *rta, int len);
+
+extern void nlattr_put(struct nlmsghdr *nlh, unsigned short type, size_t len, const void *data);
+extern struct nlattr *nlattr_nest_start(struct nlmsghdr *nlh, unsigned short type); 
+extern void nlattr_nest_end(struct nlmsghdr *nlh, struct nlattr *start);
 
 #define parse_rtattr_nested(tb, max, rta) \
 	(parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))

--- a/accel-pppd/libnetlink/nftables_set.c
+++ b/accel-pppd/libnetlink/nftables_set.c
@@ -1,0 +1,278 @@
+#include "config.h" 
+
+#ifdef HAVE_NFTABLES
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <net/if_arp.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/uio.h>
+#include <linux/netfilter/nfnetlink.h>
+#include <linux/netfilter/nf_tables.h>
+#include <linux/netfilter.h>
+
+#include "triton.h"
+#include "log.h"
+
+#include "libnetlink.h" 
+#include "nftables_set.h"
+
+#include "memdebug.h"
+
+struct nlmsghdr *__build_nlmsghdr(uint8_t *buf, uint16_t type, uint8_t family, uint16_t flags, uint32_t seq, uint16_t res_id)
+{
+    struct nlmsghdr *nlh;
+    struct nfgenmsg *nfh;
+    uint8_t *ptr;
+    size_t len;
+
+    len = NLA_ALIGN(sizeof(struct nlmsghdr));
+    nlh = (struct nlmsghdr *)buf; 
+    memset(buf, 0, len);
+
+    nlh->nlmsg_len = len; 
+    nlh->nlmsg_type = type;
+    nlh->nlmsg_flags = NLM_F_REQUEST | flags;
+    nlh->nlmsg_seq = seq; 
+
+    ptr = (uint8_t *)nlh + nlh->nlmsg_len;
+    len = NLA_ALIGN(sizeof(struct nfgenmsg));
+    nlh->nlmsg_len += len;
+    memset(ptr, 0, len);
+    nfh = (struct nfgenmsg *)ptr;	
+    nfh->nfgen_family = family;
+    nfh->version = NFNETLINK_V0;
+    nfh->res_id = htons(res_id); 
+
+    return nlh;
+}
+
+int __nftables_set_cmd(struct nftables_set_key *key, uint32_t addr, uint16_t type, uint16_t flags) 
+{    
+    struct rtnl_handle rth;
+    struct nlmsghdr *hdr;
+    struct nlattr *nest1, *nest2, *nest3;
+
+    uint8_t buf[4096];
+    uint8_t *bufptr = buf;
+
+    int buflen = 0;
+    int seq = time(NULL);
+
+    if (rtnl_open_byproto(&rth, 0, NETLINK_NETFILTER)) {
+        log_error("nftables_set: cannot open rtnetlink\n");
+        return -1;
+    }
+ 
+    hdr = __build_nlmsghdr(bufptr, 
+        NFNL_MSG_BATCH_BEGIN, 
+        AF_UNSPEC,
+        0, seq++, NFNL_SUBSYS_NFTABLES);
+
+    buflen += hdr->nlmsg_len;   
+    bufptr += hdr->nlmsg_len;
+
+    hdr = __build_nlmsghdr(bufptr, 
+        (NFNL_SUBSYS_NFTABLES << 8) | type,
+        key->family,
+        flags,
+        seq++, 0);  
+ 
+    nlattr_put(hdr, NFTA_SET_ELEM_LIST_SET, strlen(key->set)+1, key->set); 
+    nlattr_put(hdr, NFTA_SET_ELEM_LIST_TABLE, strlen(key->table)+1, key->table);
+    nest1 = nlattr_nest_start(hdr, NFTA_SET_ELEM_LIST_ELEMENTS);
+    nest2 = nlattr_nest_start(hdr, 1);  
+    nest3 = nlattr_nest_start(hdr, NFTA_SET_ELEM_KEY); 
+    nlattr_put(hdr, NFTA_DATA_VALUE, sizeof(uint32_t), &addr);
+    nlattr_nest_end(hdr, nest3);
+    nlattr_nest_end(hdr, nest2);
+    nlattr_nest_end(hdr, nest1);
+
+    buflen += hdr->nlmsg_len;	 
+    bufptr += hdr->nlmsg_len;
+
+    hdr = __build_nlmsghdr(bufptr, 
+        NFNL_MSG_BATCH_END, 
+        AF_UNSPEC,
+        0, seq++, NFNL_SUBSYS_NFTABLES);
+
+    buflen += hdr->nlmsg_len;   
+
+    if (rtnl_send_check(&rth, (const char *)buf, buflen) < 0)
+        goto out_err;
+
+    rtnl_close(&rth);
+
+    return 0;
+
+out_err:
+    rtnl_close(&rth);
+
+    return -1; 
+}
+ 
+int __export nftables_set_add(struct nftables_set_key *key, uint32_t addr)
+{ 
+    return __nftables_set_cmd(key, addr, NFT_MSG_NEWSETELEM, NLM_F_CREATE | NLM_F_EXCL | NLM_F_ACK);
+}
+ 
+int __export nftables_set_del(struct nftables_set_key *key, uint32_t addr)
+{  
+    return __nftables_set_cmd(key, addr, NFT_MSG_DELSETELEM, NLM_F_ACK);
+}
+
+int __export nftables_set_flush(struct nftables_set_key *key)
+{ 
+    struct rtnl_handle rth;
+    struct nlmsghdr *hdr; 
+
+    uint8_t buf[4096];
+    uint8_t *bufptr = buf;
+
+    int buflen = 0;
+    int seq = time(NULL);
+
+    if (rtnl_open_byproto(&rth, 0, NETLINK_NETFILTER)) {
+        log_error("nftables_set: cannot open rtnetlink\n");
+        return -1;
+    }
+ 
+    hdr = __build_nlmsghdr(bufptr, 
+        NFNL_MSG_BATCH_BEGIN, 
+        AF_UNSPEC,
+        0, seq++, NFNL_SUBSYS_NFTABLES);
+
+    buflen += hdr->nlmsg_len;   
+    bufptr += hdr->nlmsg_len;
+
+    hdr = __build_nlmsghdr(bufptr, 
+        (NFNL_SUBSYS_NFTABLES << 8) | NFT_MSG_DELSETELEM,
+        key->family,
+        NLM_F_ACK, seq++, 0);
+
+    nlattr_put(hdr, NFTA_SET_ELEM_LIST_SET, strlen(key->set)+1, key->set); 
+    nlattr_put(hdr, NFTA_SET_ELEM_LIST_TABLE, strlen(key->table)+1, key->table);  
+
+    buflen += hdr->nlmsg_len;	 
+    bufptr += hdr->nlmsg_len;
+
+    hdr = __build_nlmsghdr(bufptr, 
+        NFNL_MSG_BATCH_END, 
+        AF_UNSPEC,
+        0, seq++, NFNL_SUBSYS_NFTABLES);
+
+    buflen += hdr->nlmsg_len; 
+
+    if (rtnl_send_check(&rth, (const char *)buf, buflen) < 0)
+        goto out_err;
+
+    rtnl_close(&rth);
+
+    return 0;
+
+out_err:
+    rtnl_close(&rth);
+
+    return -1; 
+}
+
+int __export parse_nftables_set_key_conf(const char *config, struct nftables_set_key *key) {
+    if (!config) {
+        return 0;
+    }
+
+    struct nftables_set_key option = {.family = NFPROTO_UNSPEC, .table="", .set=""}; 
+
+    char *cfg = _strdup(config);
+    char *save1, *save2;
+
+    char *pair = strtok_r(cfg, ",", &save1);
+
+    while (pair) {
+        char *key = strtok_r(pair, "=", &save2);
+        char *value = strtok_r(NULL, "=", &save2);
+        if (key && value) {
+            if (strcmp(key, "family") == 0) {
+                if (strcmp(value, "inet") == 0) {
+                    option.family = NFPROTO_INET;
+                } else if (strcmp(value, "ip") == 0) {
+                    option.family = NFPROTO_IPV4;
+                } else {
+                    log_error("l4-redirect-nftables: family=%s, but key value must be one of 'ip', 'inet'\n", value);
+                    goto error;
+                }
+            } else if (strcmp(key, "table") == 0) {
+                snprintf(option.table, sizeof(option.table), "%s", value);
+            } else if (strcmp(key, "set") == 0) {
+                snprintf(option.set, sizeof(option.set), "%s", value);
+            }
+        }
+        pair = strtok_r(NULL, ",", &save1);
+    }
+
+    if (option.family == NFPROTO_UNSPEC) {
+        log_error("l4-redirect-nftables: parsing failed, family=<ip|inet> key value missing\n");
+        goto error;
+    }
+
+    if (option.table[0] == '\0') {
+        log_error("l4-redirect-nftables: parsing failed, table=<name> key value missing\n");
+        goto error;
+    }
+
+    if (option.set[0] == '\0') {
+        log_error("l4-redirect-nftables: parsing failed, set=<name> key value missing\n");
+        goto error;
+    }
+
+    _free(cfg);
+    *key = option;  
+    return 1;
+
+error:  
+    _free(cfg);
+    return 0;
+}
+
+#else 
+
+#include <netinet/in.h>
+#include "triton.h"
+#include "nftables_set.h" 
+#include "log.h"
+
+int __export nftables_set_add(struct nftables_set_key *key, uint32_t addr)
+{
+    return -1;
+}
+
+int __export nftables_set_del(struct nftables_set_key *key, uint32_t addr)
+{
+    return -1;
+}
+
+int __export nftables_set_flush(struct nftables_set_key *key)
+{
+    return -1;
+}
+
+int __export parse_nftables_set_key_conf(const char *config, struct nftables_set_key *key) 
+{ 
+    if (!config) {
+        return 0;
+    }
+    
+    log_warn("l4-redirect-nftables: nftables support was not compiled in\n");
+    return 0;
+}
+
+
+#endif

--- a/accel-pppd/libnetlink/nftables_set.h
+++ b/accel-pppd/libnetlink/nftables_set.h
@@ -1,0 +1,18 @@
+#ifndef __NFTABLES_SET_H
+#define __NFTABLES_SET_H
+
+#include <netinet/in.h>
+
+struct nftables_set_key {
+    uint8_t family;
+    char table[64];
+    char set[64];
+};
+ 
+int nftables_set_add(struct nftables_set_key *key, in_addr_t addr);
+int nftables_set_del(struct nftables_set_key *key, in_addr_t addr);
+int nftables_set_flush(struct nftables_set_key *key);
+int parse_nftables_set_key_conf(const char *conf, struct nftables_set_key *key);
+
+#endif
+

--- a/config.h.in
+++ b/config.h.in
@@ -3,3 +3,4 @@
 #cmakedefine HAVE_IPSET
 #cmakedefine HAVE_SETNS
 #cmakedefine HAVE_VRF
+#cmakedefine HAVE_NFTABLES


### PR DESCRIPTION
The following new options are added to the config file under the ipoe section to accel-ppp.conf:

l4-redirect-nftables=family=[ip|inet],table=[name],set=[name] 
^ to specify a default nftables set

attr-l4-redirect-nftables=radius_attribute
^ to specify the radius attribute name that can be used to override the default nftables set e.g. in CoA requests

This feature is analogous to the existing iptables ipset implementation and supports the same features.

Sample usage with CoA:

1. Make sure you have a nftables set in your firewall defined

nft add set ip filter l4set { type ipv4_addr\; }

2. Make sure you have the correct corresponding config defined that matches the declared set

l4-redirect-nftables=family=ip,table=filter,set=l4set 
l4-redirect=L4-Redirect
attr-l4-redirect-nftables=L4-Redirect-nftables

3. Make sure you have the correct attributes defined in your radius dictionary read by accel-ppp and your radius client/server
 
ATTRIBUTE	L4-Redirect		243	integer
ATTRIBUTE	L4-Redirect-nftables	244	string

- Send a CoA request to add client's ip address to nftables set l4set (as defined by l4-redirect-nftables option):

User-Name=Foobar,L4-Redirect=1

- Send a CoA request to remove client's ip address from nftables set l4set:

User-Name=Foobar,L4-Redirect=0

- Send a CoA request to add client's ip address from nftables set otherl4set (overrides l4-redirect-nftables option)

User-Name=Foobar,L4-Redirect=1,L4-Redirect-nftables="family=ip,table=filter,set=otherl4set"

- Send a CoA request to remove client's ip address from nftables set otherl4set:

User-Name=Foobar,L4-Redirect=0,L4-Redirect-nftables="family=ip,table=filter,set=otherl4set"