### PR TITLE
hooks: Added hooks interface for future VPP integration

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -57,6 +57,9 @@ IF (HAVE_LOGWTMP)
 	ADD_DEFINITIONS(-DHAVE_LOGWTMP)
 ENDIF (HAVE_LOGWTMP)
 
+IF (HAVE_SESSION_HOOKS)
+	ADD_DEFINITIONS(-DHAVE_SESSION_HOOKS)
+ENDIF (HAVE_SESSION_HOOKS)
 
 ADD_SUBDIRECTORY(triton)
 ADD_SUBDIRECTORY(vlan-mon)
@@ -124,6 +127,7 @@ ADD_EXECUTABLE(accel-pppd
 	libnetlink/iputils.c
 	libnetlink/genl.c
 	libnetlink/ipset.c
+	libnetlink/new_link_event.c
 
 	pwdb.c
 	ipdb.c
@@ -133,9 +137,17 @@ ADD_EXECUTABLE(accel-pppd
 	utils.c
 	rbtree.c
 
+	accel_iputils.c
+
 	log.c
 	main.c
 )
+
+IF (HAVE_SESSION_HOOKS)
+	TARGET_SOURCES(accel-pppd PRIVATE
+		ap_session_hooks.c)
+	ADD_SUBDIRECTORY(session_hooks)
+ENDIF (HAVE_SESSION_HOOKS)
 
 # check if we have getcontext/setcontext
 INCLUDE(CheckFunctionExists)

--- a/accel-pppd/accel_iputils.c
+++ b/accel-pppd/accel_iputils.c
@@ -1,0 +1,120 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include "ap_session.h"
+#include "iputils.h"
+
+#include "accel_iputils.h"
+
+__export int accel_ipaddr_add(struct ap_session *ses, int ifindex, in_addr_t addr, int mask)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ipaddr_add)
+		return ses->hooks->ipaddr_add(ses, ifindex, addr, mask);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ipaddr_add(ifindex, addr, mask);
+}
+
+__export int accel_ipaddr_add_peer(struct ap_session *ses, int ifindex, in_addr_t addr, in_addr_t peer_addr)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ipaddr_add_peer)
+		return ses->hooks->ipaddr_add_peer(ses, ifindex, addr, peer_addr);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ipaddr_add_peer(ifindex, addr, peer_addr);
+}
+
+__export int accel_ipaddr_del(struct ap_session *ses, int ifindex, in_addr_t addr, int mask)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ipaddr_del)
+		return ses->hooks->ipaddr_del(ses, ifindex, addr, mask);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ipaddr_del(ifindex, addr, mask);
+}
+
+__export int accel_ipaddr_del_peer(struct ap_session *ses, int ifindex, in_addr_t addr, in_addr_t peer)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ipaddr_del_peer)
+		return ses->hooks->ipaddr_del_peer(ses, ifindex, addr, peer);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ipaddr_del_peer(ifindex, addr, peer);
+}
+
+__export int accel_iproute_add(struct ap_session *ses, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio, const char *vrf_name)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->iproute_add)
+		return ses->hooks->iproute_add(ses, ifindex, src, dst, gw, proto, mask, prio, vrf_name);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return iproute_add(ifindex, src, dst, gw, proto, mask, prio, vrf_name);
+}
+
+__export int accel_iproute_del(struct ap_session *ses, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio, const char *vrf_name)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->iproute_del)
+		return ses->hooks->iproute_del(ses, ifindex, src, dst, gw, proto, mask, prio, vrf_name);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return iproute_del(ifindex, src, dst, gw, proto, mask, prio, vrf_name);
+}
+
+__export int accel_ip6route_add(struct ap_session *ses, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio, const char *vrf_name)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ip6route_add)
+		return ses->hooks->ip6route_add(ses, ifindex, dst, pref_len, gw, proto, prio, vrf_name);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ip6route_add(ifindex, dst, pref_len, gw, proto, prio, vrf_name);
+}
+
+__export int accel_ip6route_del(struct ap_session *ses, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio, const char *vrf_name)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ip6route_del)
+		return ses->hooks->ip6route_del(ses, ifindex, dst, pref_len, gw, proto, prio, vrf_name);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ip6route_del(ifindex, dst, pref_len, gw, proto, prio, vrf_name);
+}
+
+__export int accel_ip6addr_add(struct ap_session *ses, int ifindex, struct in6_addr *addr, int prefix_len)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ip6addr_add)
+		return ses->hooks->ip6addr_add(ses, ifindex, addr, prefix_len);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ip6addr_add(ifindex, addr, prefix_len);
+}
+
+__export int accel_ip6addr_add_peer(struct ap_session *ses, int ifindex, struct in6_addr *addr, struct in6_addr *peer_addr)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ip6addr_add_peer)
+		return ses->hooks->ip6addr_add_peer(ses, ifindex, addr, peer_addr);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ip6addr_add_peer(ifindex, addr, peer_addr);
+}
+
+__export int accel_ip6addr_del(struct ap_session *ses, int ifindex, struct in6_addr *addr, int prefix_len)
+{
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->ip6addr_del)
+		return ses->hooks->ip6addr_del(ses, ifindex, addr, prefix_len);
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		return ip6addr_del(ifindex, addr, prefix_len);
+}

--- a/accel-pppd/ap_session_hooks.c
+++ b/accel-pppd/ap_session_hooks.c
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include <pthread.h>
+
+#include "triton.h"
+
+#include "ap_session_hooks.h"
+
+LIST_HEAD(ap_session_hooks_list);
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+__export
+int ap_session_hooks_register(struct ap_session_hooks_t *h)
+{
+	struct ap_session_hooks_t *it = NULL;
+	int ret = 0;
+
+	if (h == NULL || h->hooks_name == NULL)
+		return -1;
+
+	pthread_mutex_lock(&lock);
+
+	list_for_each_entry(it, &ap_session_hooks_list, entry) {
+		if (!strncmp(it->hooks_name, h->hooks_name, HOOKS_MAX_NAME_LEN)) {
+			ret = -1;
+			goto out;
+		}
+	}
+
+	list_add_tail(&h->entry, &ap_session_hooks_list);
+
+out:
+	pthread_mutex_unlock(&lock);
+	return ret;
+}
+
+__export
+void ap_session_hooks_unregister(struct ap_session_hooks_t *h)
+{
+	if (h == NULL)
+		return;
+
+	pthread_mutex_lock(&lock);
+	list_del(&h->entry);
+	pthread_mutex_unlock(&lock);
+}
+
+__export
+struct ap_session_hooks_t * ap_session_hooks_find(const char *name)
+{
+	struct ap_session_hooks_t *ret = NULL;
+	if (name == NULL)
+		return NULL;
+
+	pthread_mutex_lock(&lock);
+
+	struct ap_session_hooks_t *h = NULL;
+	list_for_each_entry(h, &ap_session_hooks_list, entry) {
+		if (!strncmp(name, h->hooks_name, HOOKS_MAX_NAME_LEN)) {
+			ret = h;
+			break;
+		}
+	}
+
+	pthread_mutex_unlock(&lock);
+	return ret;
+}

--- a/accel-pppd/ctrl/pppoe/cli.c
+++ b/accel-pppd/ctrl/pppoe/cli.c
@@ -14,12 +14,13 @@ static void show_interfaces(void *cli)
 {
 	struct pppoe_serv_t *serv;
 
-	cli_send(cli, "interface:   connections:    state:\r\n");
-	cli_send(cli, "-----------------------------------\r\n");
+	cli_send(cli, "interface:   connections:    state:    vpp-cp:\r\n");
+	cli_send(cli, "----------------------------------------------\r\n");
 
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
-		cli_sendv(cli, "%9s    %11u    %6s\r\n", serv->ifname, serv->conn_cnt, serv->stopping ? "stop" : "active");
+		cli_sendv(cli, "%9s    %11u    %6s    %7s\r\n", serv->ifname, serv->conn_cnt, serv->stopping ? "stop" : "active",
+				serv->is_vpppoe ? "enable" : "disable");
 	}
 	pthread_rwlock_unlock(&serv_lock);
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -31,6 +31,10 @@
 
 #include "memdebug.h"
 
+#include "ipdb.h"
+
+#include "new_link_event.h"
+
 #define SID_MAX 65536
 
 #ifndef min
@@ -130,6 +134,13 @@ static pthread_mutex_t sid_lock = PTHREAD_MUTEX_INITIALIZER;
 static unsigned long *sid_map;
 static unsigned long *sid_ptr;
 static int sid_idx;
+
+struct nnle_handler_t pppoe_nnle_handler;
+LIST_HEAD(monitored_link_list);
+
+static void monitored_link_list_add(const char *name, const char *opt);
+static void monitored_link_list_del(const char *name);
+struct monitored_link_list_entry_t * monitored_link_list_find(const char *name);
 
 static uint8_t bc_addr[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
@@ -1520,13 +1531,17 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
-		if (serv->net == net && !strcmp(serv->ifname, ifname)) {
+		if (serv->net == net && !strcmp(serv->ifname, ifname) && !serv->stopping) {
 			if (cli)
 				cli_send(cli, "error: already exists\r\n");
 			pthread_rwlock_unlock(&serv_lock);
 			return;
 		}
 	}
+	pthread_rwlock_unlock(&serv_lock);
+
+	pthread_rwlock_wrlock(&serv_lock);
+	monitored_link_list_add(ifname, opt);
 	pthread_rwlock_unlock(&serv_lock);
 
 	if (vid && !vlan_mon && vlan_mon_check_busy(parent_ifindex, vid))
@@ -1543,6 +1558,8 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 	}
 
 	strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+
+	serv->stop_cause = TERM_ADMIN_RESET;
 
 #ifdef HAVE_SESSION_HOOKS
 	serv->is_vpppoe = is_vpppoe;
@@ -1657,7 +1674,7 @@ out_err:
 
 static void _conn_stop(struct pppoe_conn_t *conn)
 {
-	ap_session_terminate(&conn->ppp.ses, TERM_ADMIN_RESET, 0);
+	ap_session_terminate(&conn->ppp.ses, conn->serv->stop_cause, 0);
 }
 
 void _server_stop(struct pppoe_serv_t *serv)
@@ -1712,9 +1729,13 @@ void pppoe_server_stop(const char *ifname)
 {
 	struct pppoe_serv_t *serv;
 
+	pthread_rwlock_wrlock(&serv_lock);
+	monitored_link_list_del(ifname);
+	pthread_rwlock_unlock(&serv_lock);
+
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
-		if (strcmp(serv->ifname, ifname))
+		if (strcmp(serv->ifname, ifname) || serv->stopping)
 			continue;
 		triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
 		break;
@@ -2207,6 +2228,89 @@ static void load_interfaces()
 	}
 }
 
+static void monitored_link_list_add(const char *name, const char *opt)
+{
+	struct monitored_link_list_entry_t *s;
+
+	if (name == NULL) {
+		return;
+	}
+
+	s = monitored_link_list_find(name);
+	/* TODO: update opt? */
+	/* already exists */
+	if (s != NULL)
+		return;
+
+	s = malloc(sizeof(*s));
+	s->name = strdup(name);
+	s->opt = NULL;
+	if (opt)
+		s->opt = strdup(opt);
+
+	list_add_tail(&s->entry, &monitored_link_list);
+}
+
+static void monitored_link_list_del(const char *name)
+{
+	struct monitored_link_list_entry_t *s;
+
+	s = monitored_link_list_find(name);
+	if (s == NULL)
+		return;
+
+	list_del(&s->entry);
+	free(s->name);
+	if (s->opt)
+		free(s->opt);
+
+	free(s);
+}
+
+struct monitored_link_list_entry_t * monitored_link_list_find(const char *name)
+{
+	struct monitored_link_list_entry_t *s;
+
+	if (name == NULL)
+		return NULL;
+
+	list_for_each_entry(s, &monitored_link_list, entry) {
+		if (!strncmp(name, s->name, IFNAMSIZ - 1)) {
+			return s;
+		}
+	}
+
+	return NULL;
+}
+
+static void pppoe_on_add_link(const char *name)
+{
+	pthread_rwlock_rdlock(&serv_lock);
+	struct monitored_link_list_entry_t *s = monitored_link_list_find(name);
+	pthread_rwlock_unlock(&serv_lock);
+	if (s != NULL) {
+		__pppoe_server_start(s->name, s->opt, NULL, -1, 0, 0);
+		log_info1("pppoe: new link event received, starting the service on: %s with options \"%s\"\n", s->name, s->opt);
+	}
+}
+
+static void pppoe_on_del_link(const char *name)
+{
+	/* TODO: it is a copy of pppoe_server_stop() without monitored delete */
+	struct pppoe_serv_t *serv;
+
+	pthread_rwlock_rdlock(&serv_lock);
+	list_for_each_entry(serv, &serv_list, entry) {
+		if (strcmp(serv->ifname, name) || serv->stopping)
+			continue;
+		serv->stop_cause = TERM_NAS_ERROR;
+		triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
+		log_warn("pppoe: delete link event received, stopping the service on: %s ifindex %d\n", serv->ifname, serv->ifindex);
+		break;
+	}
+	pthread_rwlock_unlock(&serv_lock);
+}
+
 static void pppoe_init(void)
 {
 	int fd;
@@ -2238,6 +2342,10 @@ static void pppoe_init(void)
 	load_config();
 
 	connlimit_loaded = triton_module_loaded("connlimit");
+
+	pppoe_nnle_handler.on_new_link = pppoe_on_add_link;
+	pppoe_nnle_handler.on_del_link = pppoe_on_del_link;
+	nnle_add_handler(&pppoe_nnle_handler);
 
 	triton_event_register_handler(EV_CONFIG_RELOAD, (triton_event_func)load_config);
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -219,6 +219,20 @@ static void ppp_started(struct ap_session *ses)
 	log_ppp_debug("pppoe: ppp started\n");
 }
 
+int pppoe_terminate(struct ap_session *ses, int hard) {
+	int ret = 0;
+
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->pppoe_terminate &&
+		ses->hooks->pppoe_terminate(ses, hard))
+		log_ppp_warn("pppoe: issue to terminate PPPoE session with hook\n");
+#endif /* HAVE_SESSION_HOOKS */
+
+	ret = ppp_terminate(ses, hard);
+
+	return ret;
+}
+
 static void ppp_finished(struct ap_session *ses)
 {
 	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
@@ -343,7 +357,7 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 	conn->ctrl.ctx = &conn->ctx;
 	conn->ctrl.started = ppp_started;
 	conn->ctrl.finished = ppp_finished;
-	conn->ctrl.terminate = ppp_terminate;
+	conn->ctrl.terminate = pppoe_terminate;
 	conn->ctrl.max_mtu = min(ETH_DATA_LEN, serv->mtu) - 8;
 	conn->ctrl.type = CTRL_TYPE_PPPOE;
 	conn->ctrl.ppp = 1;
@@ -409,6 +423,30 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 			addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 
 	ppp_init(&conn->ppp);
+
+#ifdef HAVE_SESSION_HOOKS
+	if (serv->is_vpppoe) {
+		conn->ppp.ses.hooks = serv->ses_hooks;
+		if (conn->ppp.ses.hooks->session_hook_init &&
+			conn->ppp.ses.hooks->session_hook_init(&conn->ppp.ses)) {
+			log_ppp_error("pppoe: issue to initialize hook for session.\n");
+
+			_free(conn->ctrl.service_name);
+			_free(conn->ctrl.calling_station_id);
+			_free(conn->ctrl.called_station_id);
+			_free(conn->service_name);
+			if (conn->host_uniq)
+				_free(conn->host_uniq);
+			if (conn->relay_sid)
+				_free(conn->relay_sid);
+			if (conn->tr101)
+				_free(conn->tr101);
+
+			mempool_free(conn);
+			return NULL;
+		}
+	}
+#endif /* HAVE_SESSION_HOOKS */
 
 	conn->ppp.ses.net = serv->net;
 	conn->ppp.ses.ctrl = &conn->ctrl;
@@ -1329,10 +1367,13 @@ static void pppoe_serv_timeout(struct triton_timer_t *t)
 	pppoe_server_free(serv);
 }
 
-static int parse_server(const char *opt, int *padi_limit, struct ap_net **net)
+static int parse_server(const char *opt, int *padi_limit, struct ap_net **net, int *is_vpppoe)
 {
 	char *ptr, *endptr;
-	char name[64];
+	char optval[64];
+
+	if (is_vpppoe)
+		*is_vpppoe = 0;
 
 	while (*opt == ',') {
 		opt++;
@@ -1347,13 +1388,22 @@ static int parse_server(const char *opt, int *padi_limit, struct ap_net **net)
 		} else if (!strncmp(opt, "net=", sizeof("net=") - 1)) {
 			ptr++;
 			for (endptr = ptr + 1; *endptr && *endptr != ','; endptr++);
-			if (endptr - ptr >= sizeof(name))
+			if (endptr - ptr >= sizeof(optval))
 				goto out_err;
-			memcpy(name, ptr, endptr - ptr);
-			name[endptr - ptr] = 0;
-			*net = ap_net_find(name);
+			memcpy(optval, ptr, endptr - ptr);
+			optval[endptr - ptr] = 0;
+			*net = ap_net_find(optval);
 			if (!*net)
 				goto out_err;
+		} else if (!strncmp(opt, "vpp-cp=", sizeof("vpp-cp=") - 1)) {
+			ptr++;
+			for (endptr = ptr + 1; *endptr && *endptr != ','; endptr++);
+			memcpy(optval, ptr, endptr - ptr);
+			optval[endptr - ptr] = 0;
+			if (is_vpppoe)
+				*is_vpppoe = !strncasecmp(optval, "enable", sizeof("enable") - 1) ||
+								!strncasecmp(optval, "true", sizeof("true") - 1) ||
+								!strncasecmp(optval, "1", sizeof("1") - 1);
 		} else
 			goto out_err;
 	}
@@ -1445,9 +1495,10 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 	struct pppoe_serv_t *serv;
 	struct ifreq ifr;
 	int padi_limit = conf_padi_limit;
+	int is_vpppoe = 0;
 	net = def_net;
 
-	if (parse_server(opt, &padi_limit, &net)) {
+	if (parse_server(opt, &padi_limit, &net, &is_vpppoe)) {
 		if (cli)
 			cli_sendv(cli, "failed to parse '%s'\r\n", opt);
 		else
@@ -1455,6 +1506,17 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 
 		return;
 	}
+
+#ifndef HAVE_SESSION_HOOKS
+	if (is_vpppoe) {
+		if (cli)
+			cli_sendv(cli, "No support for vpp, option vpp-cp invalid for interface %s\r\n", ifname);
+		else
+			log_error("pppoe: No support for vpp, option vpp-cp invalid for interface %s\r\n", ifname);
+
+		return;
+	}
+#endif /* HAVE_SESSION_HOOKS */
 
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
@@ -1481,6 +1543,23 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 	}
 
 	strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+
+#ifdef HAVE_SESSION_HOOKS
+	serv->is_vpppoe = is_vpppoe;
+	if (serv->is_vpppoe) {
+		struct ap_session_hooks_t *ses_hooks = NULL;
+		ses_hooks = ap_session_hooks_find("vpp");
+		if (ses_hooks == NULL) {
+			if (cli)
+				cli_sendv(cli, "No \"vpp\" session hooks are present, load the VPP plugin\r\n");
+			log_error("No \"vpp\" session hooks are present, load the VPP plugin\n");
+			_free(serv);
+			return;
+		}
+
+		serv->ses_hooks = ses_hooks;
+	}
+#endif /* HAVE_SESSION_HOOKS */
 
 	if (net->sock_ioctl(SIOCGIFFLAGS, &ifr)) {
 		if (cli)
@@ -1647,6 +1726,15 @@ void __export pppoe_get_stat(unsigned int **starting, unsigned int **active)
 {
 	*starting = &stat_starting;
 	*active = &stat_active;
+}
+
+void __export pppoe_get_session_mac_and_sid(struct ap_session *ses, uint8_t **mac, uint16_t *sid)
+{
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+	struct pppoe_conn_t *conn = container_of(ppp, typeof(*conn), ppp);
+
+	*mac = conn->addr;
+	*sid = conn->sid;
 }
 
 static int init_secret(struct pppoe_serv_t *serv)

--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -106,6 +106,7 @@ struct pppoe_serv_t
 	unsigned int stopping:1;
 	unsigned int vlan_mon:1;
 	unsigned int is_vpppoe:1;
+	unsigned int stop_cause;
 
 #ifdef HAVE_SESSION_HOOKS
 	/* hooks set to sessions for this server */
@@ -132,6 +133,13 @@ extern unsigned long stat_filtered;
 
 extern pthread_rwlock_t serv_lock;
 extern struct list_head serv_list;
+
+struct monitored_link_list_entry_t {
+	struct list_head entry;
+	char *name;
+	char *opt;
+};
+extern struct list_head monitored_link_list;
 
 int mac_filter_check(const uint8_t *addr);
 void pppoe_server_start(const char *intf, void *client);

--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -11,6 +11,10 @@
 
 #include "rbtree.h"
 
+#ifdef HAVE_SESSION_HOOKS
+# include "ap_session_hooks.h"
+#endif /* HAVE_SESSION_HOOKS */
+
 /* PPPoE codes */
 #define CODE_PADI           0x09
 #define CODE_PADO           0x07
@@ -101,6 +105,12 @@ struct pppoe_serv_t
 
 	unsigned int stopping:1;
 	unsigned int vlan_mon:1;
+	unsigned int is_vpppoe:1;
+
+#ifdef HAVE_SESSION_HOOKS
+	/* hooks set to sessions for this server */
+	struct ap_session_hooks_t *ses_hooks;
+#endif /* HAVE_SESSION_HOOKS */
 };
 
 extern int conf_verbose;

--- a/accel-pppd/ifcfg.c
+++ b/accel-pppd/ifcfg.c
@@ -98,6 +98,12 @@ void __export ap_session_accounting_started(struct ap_session *ses)
 	if (ses->stop_time)
 		return;
 
+#ifdef HAVE_SESSION_HOOKS
+	/* Skip completely ifcfg routine for non-dev-ppp sessions */
+	if (ses->hooks && ses->hooks->pppoe_create_session_interface)
+		goto skip_ifcfg;
+#endif /* HAVE_SESSION_HOOKS */
+
 	memset(&ifr, 0, sizeof(ifr));
 	strcpy(ifr.ifr_name, ses->ifname);
 
@@ -188,6 +194,10 @@ void __export ap_session_accounting_started(struct ap_session *ses)
 		}
 #endif
 	}
+
+#ifdef HAVE_SESSION_HOOKS
+skip_ifcfg:
+#endif /* HAVE_SESSION_HOOKS */
 
 	ses->ctrl->started(ses);
 

--- a/accel-pppd/include/accel_iputils.h
+++ b/accel-pppd/include/accel_iputils.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#ifndef ACCEL_IPUTILS_H
+#define ACCEL_IPUTILS_H
+
+int accel_ipaddr_add(struct ap_session *ses, int ifindex, in_addr_t addr, int mask);
+int accel_ipaddr_add_peer(struct ap_session *ses, int ifindex, in_addr_t addr, in_addr_t peer_addr);
+int accel_ipaddr_del(struct ap_session *ses, int ifindex, in_addr_t addr, int mask);
+int accel_ipaddr_del_peer(struct ap_session *ses, int ifindex, in_addr_t addr, in_addr_t peer);
+int accel_iproute_add(struct ap_session *ses, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio, const char *vrf_name);
+int accel_iproute_del(struct ap_session *ses, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio, const char *vrf_name);
+int accel_ip6route_add(struct ap_session *ses, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio, const char *vrf_name);
+int accel_ip6route_del(struct ap_session *ses, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio, const char *vrf_name);
+int accel_ip6addr_add(struct ap_session *ses, int ifindex, struct in6_addr *addr, int prefix_len);
+int accel_ip6addr_add_peer(struct ap_session *ses, int ifindex, struct in6_addr *addr, struct in6_addr *peer_addr);
+int accel_ip6addr_del(struct ap_session *ses, int ifindex, struct in6_addr *addr, int prefix_len);
+
+#endif /* ACCEL_IPUTILS_H */

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -5,9 +5,10 @@
 
 #include "triton.h"
 #include "ap_net.h"
+#include "ap_session_hooks.h"
 
 //#define AP_SESSIONID_LEN 16
-#define AP_IFNAME_LEN 16
+#define AP_IFNAME_LEN 64
 
 #define AP_STATE_STARTING  1
 #define AP_STATE_ACTIVE    2

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -120,6 +120,9 @@ struct ap_session
 	uint64_t acct_rx_bytes_i;
 	uint64_t acct_tx_bytes_i;
 	int acct_start;
+#ifdef HAVE_SESSION_HOOKS
+	struct ap_session_hooks_t *hooks;
+#endif /* HAVE_SESSION_HOOKS */
 };
 
 struct ap_session_stat

--- a/accel-pppd/include/ap_session_hooks.h
+++ b/accel-pppd/include/ap_session_hooks.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#ifndef AP_SESSION_HOOKS_H
+#define AP_SESSION_HOOKS_H
+
+#include <netinet/in.h>
+
+#include "list.h"
+
+#define HOOKS_MAX_NAME_LEN 128
+
+struct ap_session;
+/*
+ * Hooks are presented mostly for VPP and are designed
+ * to present the VPP routine as a separate plugin.
+ */
+struct ap_session_hooks_t {
+	/* init hook per session - on session create, init hook's "private" structures etc. */
+	int (*session_hook_init)(struct ap_session *ses);
+	/* per session - on session free, deinit hook's structures etc. */
+	void (*session_hook_deinit)(struct ap_session *ses);
+
+	/*
+	 * hooks to create a proper session interface
+	 * in case of "non-dev" ppp(/dev/ppp)
+	 * called from ap_session_activate()
+	 */
+	int (*pppoe_create_session_interface)(struct ap_session *ses);
+	int (*pppoe_terminate)(struct ap_session *ses, int hard);
+
+	/* route related hooks called from accel_iputils */
+	int (*ipaddr_add)(struct ap_session *ses, int ifindex, in_addr_t addr, int mask);
+	int (*ipaddr_add_peer)(struct ap_session *ses, int ifindex, in_addr_t addr, in_addr_t peer_addr);
+	int (*ipaddr_del)(struct ap_session *ses, int ifindex, in_addr_t addr, int mask);
+	int (*ipaddr_del_peer)(struct ap_session *ses, int ifindex, in_addr_t addr, in_addr_t peer);
+	int (*iproute_add)(struct ap_session *ses, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio, const char *vrf_name);
+	int (*iproute_del)(struct ap_session *ses, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio, const char *vrf_name);
+	int (*ip6route_add)(struct ap_session *ses, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio, const char *vrf_name);
+	int (*ip6route_del)(struct ap_session *ses, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio, const char *vrf_name);
+	int (*ip6addr_add)(struct ap_session *ses, int ifindex, struct in6_addr *addr, int prefix_len);
+	int (*ip6addr_add_peer)(struct ap_session *ses, int ifindex, struct in6_addr *addr, struct in6_addr *peer_addr);
+	int (*ip6addr_del)(struct ap_session *ses, int ifindex, struct in6_addr *addr, int prefix_len);
+
+	/* limiter related, check shaper/limiter.c */
+	int (*install_limiter)(struct ap_session *ses, int down_speed, int down_burst, int up_speed, int up_burst);
+	int (*remove_limiter)(struct ap_session *ses);
+
+	/* flags */
+	uint8_t is_non_dev_ppp:1; /* do not create the ppp device with /dev/ppp */
+	uint8_t is_non_socket_dhcpv6_nd:1; /* do not create a sockets for DHCPv6 and ND - use chanel socket */
+
+	/**/
+	struct list_head entry;
+	const char *hooks_name; /* g.e. "vpp" */
+};
+
+int ap_session_hooks_register(struct ap_session_hooks_t *h);
+void ap_session_hooks_unregister(struct ap_session_hooks_t *h);
+struct ap_session_hooks_t * ap_session_hooks_find(const char *name);
+
+#endif /* AP_SESSION_HOOKS_H */

--- a/accel-pppd/include/new_link_event.h
+++ b/accel-pppd/include/new_link_event.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include "list.h"
+
+/* nnle: Netlink New Link Event */
+
+struct nnle_handler_t {
+	list_t entry;
+	void (*on_new_link)(const char *name);
+	void (*on_del_link)(const char *name);
+};
+
+void nnle_add_handler(struct nnle_handler_t *h);
+void nnle_del_handler(struct nnle_handler_t *h);

--- a/accel-pppd/ipv6/CMakeLists.txt
+++ b/accel-pppd/ipv6/CMakeLists.txt
@@ -1,6 +1,11 @@
 ADD_LIBRARY(ipv6_dhcp SHARED dhcpv6.c dhcpv6_packet.c)
 ADD_LIBRARY(ipv6_nd SHARED nd.c)
 
+IF (HAVE_SESSION_HOOKS)
+	TARGET_SOURCES(ipv6_dhcp PRIVATE ppp_ipv6layer.c)
+	TARGET_SOURCES(ipv6_nd PRIVATE ppp_ipv6layer.c)
+ENDIF (HAVE_SESSION_HOOKS)
+
 INSTALL(TARGETS ipv6_dhcp ipv6_nd
 	LIBRARY DESTINATION lib${LIB_SUFFIX}/accel-ppp
 )

--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -26,6 +26,10 @@
 #include "dhcpv6.h"
 
 #include "memdebug.h"
+
+#ifdef HAVE_SESSION_HOOKS
+# include "ppp_ipv6layer.h"
+#endif /* HAVE_SESSION_HOOKS */
 #include "accel_iputils.h"
 
 #define BUF_SIZE 65536
@@ -64,13 +68,17 @@ static void *pd_key;
 
 static int dhcpv6_read(struct triton_md_handler_t *h);
 
+#ifdef HAVE_SESSION_HOOKS
+__export int dhcpv6_external_process_udp(struct ap_session *ses, const void *buf, size_t n, struct in6_addr *addr, unsigned short port);
+#endif /* HAVE_SESSION_HOOKS */
+
 static void ev_ses_started(struct ap_session *ses)
 {
 	struct ipv6_mreq mreq;
 	struct dhcpv6_pd *pd;
 	struct sockaddr_in6 addr;
 	struct ipv6db_addr_t *a;
-	int sock;
+	int sock = -1;
 	int f = 1;
 
 	if (!ses->ipv6 || list_empty(&ses->ipv6->addr_list))
@@ -80,46 +88,53 @@ static void ev_ses_started(struct ap_session *ses)
 	if (a->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&a->addr))
 		return;
 
-	net->enter_ns();
-	sock = net->socket(AF_INET6, SOCK_DGRAM, 0);
-	net->exit_ns();
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_enable_dhcpv6(ses, dhcpv6_external_process_udp);
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		net->enter_ns();
+		sock = net->socket(AF_INET6, SOCK_DGRAM, 0);
+		net->exit_ns();
 
-	if (!sock) {
-		log_ppp_error("dhcpv6: socket: %s\n", strerror(errno));
-		return;
+		if (!sock) {
+			log_ppp_error("dhcpv6: socket: %s\n", strerror(errno));
+			return;
+		}
+
+		net->setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &f, sizeof(f));
+
+		if (net->setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, ses->ifname, strlen(ses->ifname))) {
+			log_ppp_error("dhcpv6: setsockopt(SO_BINDTODEVICE): %s\n", strerror(errno));
+			close(sock);
+			return;
+		}
+
+		memset(&addr, 0, sizeof(addr));
+		addr.sin6_family = AF_INET6;
+		addr.sin6_port = htons(DHCPV6_SERV_PORT);
+
+		if (net->bind(sock, (struct sockaddr *)&addr, sizeof(addr))) {
+			log_ppp_error("dhcpv6: bind: %s\n", strerror(errno));
+			close(sock);
+			return;
+		}
+
+		memset(&mreq, 0, sizeof(mreq));
+		mreq.ipv6mr_interface = ses->ifindex;
+		mreq.ipv6mr_multiaddr.s6_addr32[0] = htonl(0xff020000);
+		mreq.ipv6mr_multiaddr.s6_addr32[3] = htonl(0x010002);
+
+		if (net->setsockopt(sock, SOL_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq))) {
+			log_ppp_error("dhcpv6: failed to join to All_DHCP_Relay_Agents_and_Servers\n");
+			close(sock);
+			return;
+		}
+
+		fcntl(sock, F_SETFD, fcntl(sock, F_GETFD) | FD_CLOEXEC);
+		net->set_nonblocking(sock, 1);
 	}
-
-	net->setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &f, sizeof(f));
-
-	if (net->setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, ses->ifname, strlen(ses->ifname))) {
-		log_ppp_error("dhcpv6: setsockopt(SO_BINDTODEVICE): %s\n", strerror(errno));
-		close(sock);
-		return;
-	}
-
-	memset(&addr, 0, sizeof(addr));
-	addr.sin6_family = AF_INET6;
-	addr.sin6_port = htons(DHCPV6_SERV_PORT);
-
-	if (net->bind(sock, (struct sockaddr *)&addr, sizeof(addr))) {
-		log_ppp_error("dhcpv6: bind: %s\n", strerror(errno));
-		close(sock);
-		return;
-	}
-
-	memset(&mreq, 0, sizeof(mreq));
-	mreq.ipv6mr_interface = ses->ifindex;
-	mreq.ipv6mr_multiaddr.s6_addr32[0] = htonl(0xff020000);
-	mreq.ipv6mr_multiaddr.s6_addr32[3] = htonl(0x010002);
-
-	if (net->setsockopt(sock, SOL_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq))) {
-		log_ppp_error("dhcpv6: failed to join to All_DHCP_Relay_Agents_and_Servers\n");
-		close(sock);
-		return;
-	}
-
-	fcntl(sock, F_SETFD, fcntl(sock, F_GETFD) | FD_CLOEXEC);
-	net->set_nonblocking(sock, 1);
 
 	pd = _malloc(sizeof(*pd));
 	memset(pd, 0, sizeof(*pd));
@@ -129,10 +144,15 @@ static void ev_ses_started(struct ap_session *ses)
 
 	pd->ses = ses;
 
-	pd->hnd.fd = sock;
-	pd->hnd.read = dhcpv6_read;
-	triton_md_register_handler(ses->ctrl->ctx, &pd->hnd);
-	triton_md_enable_handler(&pd->hnd, MD_MODE_READ);
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd))
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		pd->hnd.fd = sock;
+		pd->hnd.read = dhcpv6_read;
+		triton_md_register_handler(ses->ctrl->ctx, &pd->hnd);
+		triton_md_enable_handler(&pd->hnd, MD_MODE_READ);
+	}
 }
 
 static struct dhcpv6_pd *find_pd(struct ap_session *ses)
@@ -169,7 +189,14 @@ static void ev_ses_finished(struct ap_session *ses)
 		ipdb_put_ipv6_prefix(ses, ses->ipv6_dp);
 	}
 
-	triton_md_unregister_handler(&pd->hnd, 1);
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_disable_dhcpv6(ses);
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		triton_md_unregister_handler(&pd->hnd, 1);
+	}
 
 	_free(pd);
 }
@@ -463,7 +490,15 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 
 	dhcpv6_fill_relay_info(reply);
 
-	net->sendto(pd->hnd.fd, reply->hdr, reply->endptr - (void *)reply->hdr, 0, (struct sockaddr *)&req->addr, sizeof(req->addr));
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_dhcpv6_send(ses, reply->hdr, reply->endptr - (void *)reply->hdr, (struct sockaddr *)&req->addr, sizeof(req->addr));
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		req->addr.sin6_scope_id = ses->ifindex;
+		net->sendto(pd->hnd.fd, reply->hdr, reply->endptr - (void *)reply->hdr, 0, (struct sockaddr *)&req->addr, sizeof(req->addr));
+	}
 
 	dhcpv6_packet_free(reply);
 }
@@ -618,7 +653,15 @@ static void dhcpv6_send_reply2(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, 
 
 	dhcpv6_fill_relay_info(reply);
 
-	net->sendto(pd->hnd.fd, reply->hdr, reply->endptr - (void *)reply->hdr, 0, (struct sockaddr *)&req->addr, sizeof(req->addr));
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_dhcpv6_send(ses, reply->hdr, reply->endptr - (void *)reply->hdr, (struct sockaddr *)&req->addr, sizeof(req->addr));
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		req->addr.sin6_scope_id = ses->ifindex;
+		net->sendto(pd->hnd.fd, reply->hdr, reply->endptr - (void *)reply->hdr, 0, (struct sockaddr *)&req->addr, sizeof(req->addr));
+	}
 
 out:
 	dhcpv6_packet_free(reply);
@@ -827,6 +870,43 @@ static void dhcpv6_recv_packet(struct dhcpv6_packet *pkt)
 	dhcpv6_packet_free(pkt);
 }
 
+int dhcpv6_read_process_udp(struct ap_session *ses, struct dhcpv6_pd *pd, const uint8_t *buf, int n, struct sockaddr_in6 *addr) {
+
+	struct dhcpv6_packet *pkt;
+
+	if (!IN6_IS_ADDR_LINKLOCAL(&addr->sin6_addr))
+		return 1;
+
+	if (addr->sin6_port != ntohs(DHCPV6_CLIENT_PORT))
+		return 1;
+
+	pkt = dhcpv6_packet_parse(buf, n);
+	if (!pkt || !pkt->clientid) {
+		return 1;
+	}
+
+	pkt->ses = ses;
+	pkt->pd = pd;
+	pkt->addr = *addr;
+
+	dhcpv6_recv_packet(pkt);
+
+	return 0;
+}
+
+#ifdef HAVE_SESSION_HOOKS
+int dhcpv6_external_process_udp(struct ap_session *ses, const void *buf, size_t n, struct in6_addr *addr, unsigned short port)
+{
+	struct dhcpv6_pd *pd = find_pd(ses); /* TODO: add check */
+	struct sockaddr_in6 saddr;
+	saddr.sin6_family = AF_INET6;
+	memcpy(&saddr.sin6_addr, addr, sizeof(*addr));
+	saddr.sin6_port = port;
+
+	return dhcpv6_read_process_udp(ses, pd, (const uint8_t *)buf, n, &saddr);
+}
+#endif /* HAVE_SESSION_HOOKS */
+
 static int dhcpv6_read(struct triton_md_handler_t *h)
 {
 	struct dhcpv6_pd *pd = container_of(h, typeof(*pd), hnd);
@@ -834,7 +914,6 @@ static int dhcpv6_read(struct triton_md_handler_t *h)
 	int n;
 	struct sockaddr_in6 addr;
 	socklen_t len = sizeof(addr);
-	struct dhcpv6_packet *pkt;
 	uint8_t *buf = _malloc(BUF_SIZE);
 
 	while (1) {
@@ -846,22 +925,7 @@ static int dhcpv6_read(struct triton_md_handler_t *h)
 			continue;
 		}
 
-		if (!IN6_IS_ADDR_LINKLOCAL(&addr.sin6_addr))
-			continue;
-
-		if (addr.sin6_port != ntohs(DHCPV6_CLIENT_PORT))
-			continue;
-
-		pkt = dhcpv6_packet_parse(buf, n);
-		if (!pkt || !pkt->clientid) {
-			continue;
-		}
-
-		pkt->ses = ses;
-		pkt->pd = pd;
-		pkt->addr = addr;
-
-		dhcpv6_recv_packet(pkt);
+		dhcpv6_read_process_udp(ses, pd, buf, n, &addr);
 	}
 
 	_free(buf);

--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -26,6 +26,7 @@
 #include "dhcpv6.h"
 
 #include "memdebug.h"
+#include "accel_iputils.h"
 
 #define BUF_SIZE 65536
 #define MAX_DNS_COUNT 3
@@ -162,7 +163,7 @@ static void ev_ses_finished(struct ap_session *ses)
 		if (pd->dp_active) {
 			struct ipv6db_addr_t *p;
 			list_for_each_entry(p, &ses->ipv6_dp->prefix_list, entry)
-				ip6route_del(0, &p->addr, p->prefix_len, NULL, 0, 0, NULL);
+				accel_ip6route_del(ses, 0, &p->addr, p->prefix_len, NULL, 0, 0, NULL);
 		}
 
 		ipdb_put_ipv6_prefix(ses, ses->ipv6_dp);
@@ -184,7 +185,7 @@ static void insert_dp_routes(struct ap_session *ses, struct dhcpv6_pd *pd, struc
 		addr = NULL;
 
 	list_for_each_entry(p, &ses->ipv6_dp->prefix_list, entry) {
-		if (ip6route_add(ses->ifindex, &p->addr, p->prefix_len, addr, 0, 0, NULL)) {
+		if (accel_ip6route_add(ses, ses->ifindex, &p->addr, p->prefix_len, addr, 0, 0,NULL)) {
 			err = errno;
 			inet_ntop(AF_INET6, &p->addr, str1, sizeof(str1));
 			if (addr)
@@ -303,12 +304,12 @@ static void dhcpv6_send_reply(struct dhcpv6_packet *req, struct dhcpv6_pd *pd, i
 							memcpy(addr.s6_addr + 8, &ses->ipv6->intf_id, 8);
 							memcpy(peer_addr.s6_addr, &a->addr, 8);
 							memcpy(peer_addr.s6_addr + 8, &ses->ipv6->peer_intf_id, 8);
-							ip6addr_add_peer(ses->ifindex, &addr, &peer_addr);
+							accel_ip6addr_add_peer(ses, ses->ifindex, &addr, &peer_addr);
 						} else {
 							build_ip6_addr(a, ses->ipv6->intf_id, &addr);
 							if (memcmp(&addr, &ia_addr->addr, sizeof(addr)) == 0)
 								build_ip6_addr(a, ~ses->ipv6->intf_id, &addr);
-							ip6addr_add(ses->ifindex, &addr, a->prefix_len);
+							accel_ip6addr_add(ses, ses->ifindex, &addr, a->prefix_len);
 						}
 						a->installed = 1;
 					}

--- a/accel-pppd/ipv6/nd.c
+++ b/accel-pppd/ipv6/nd.c
@@ -18,6 +18,7 @@
 #include "mempool.h"
 #include "ipdb.h"
 #include "iputils.h"
+#include "accel_iputils.h"
 
 #include "memdebug.h"
 
@@ -151,13 +152,13 @@ static void ipv6_nd_send_ra(struct ipv6_nd_handler_t *h, struct sockaddr_in6 *ds
 				memcpy(addr.s6_addr + 8, &ses->ipv6->intf_id, 8);
 				memcpy(peer_addr.s6_addr, &a->addr, 8);
 				memcpy(peer_addr.s6_addr + 8, &ses->ipv6->peer_intf_id, 8);
-				ip6addr_add_peer(ses->ifindex, &addr, &peer_addr);
+				accel_ip6addr_add_peer(ses, ses->ifindex, &addr, &peer_addr);
 			} else {
 				build_ip6_addr(a, ses->ipv6->intf_id, &addr);
 				build_ip6_addr(a, ses->ipv6->peer_intf_id, &peer_addr);
 				if (memcmp(&addr, &peer_addr, sizeof(addr)) == 0)
 					build_ip6_addr(a, ~ses->ipv6->intf_id, &addr);
-				ip6addr_add(ses->ifindex, &addr, a->prefix_len);
+				accel_ip6addr_add(ses, ses->ifindex, &addr, a->prefix_len);
 			}
 			a->installed = 1;
 		}

--- a/accel-pppd/ipv6/nd.c
+++ b/accel-pppd/ipv6/nd.c
@@ -18,6 +18,10 @@
 #include "mempool.h"
 #include "ipdb.h"
 #include "iputils.h"
+
+#ifdef HAVE_SESSION_HOOKS
+# include "ppp_ipv6layer.h"
+#endif /* HAVE_SESSION_HOOKS */
 #include "accel_iputils.h"
 
 #include "memdebug.h"
@@ -201,7 +205,14 @@ static void ipv6_nd_send_ra(struct ipv6_nd_handler_t *h, struct sockaddr_in6 *ds
 	} else
 		endptr = rdnss_addr;
 
-	net->sendto(h->hnd.fd, buf, endptr - buf, 0, (struct sockaddr *)dst_addr, sizeof(*dst_addr));
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_icmpv6_send(h->ses, buf, endptr - buf, (struct sockaddr *)dst_addr, sizeof(*dst_addr));
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		net->sendto(h->hnd.fd, buf, endptr - buf, 0, (struct sockaddr *)dst_addr, sizeof(*dst_addr));
+	}
 
 	mempool_free(buf);
 }
@@ -227,6 +238,28 @@ static void send_ra_timer(struct triton_timer_t *t)
 	ipv6_nd_send_ra(h, &addr);
 }
 
+int ipv6_nd_process_icmp(struct ipv6_nd_handler_t *h, const struct icmp6_hdr *icmph, struct sockaddr_in6 *addr)
+{
+	if (icmph->icmp6_type != ND_ROUTER_SOLICIT) {
+		log_ppp_warn("ipv6_nd: received unexcpected icmp packet (%i)\n", icmph->icmp6_type);
+		return 1;
+	}
+
+	if (!IN6_IS_ADDR_LINKLOCAL(&addr->sin6_addr)) {
+		log_ppp_warn("ipv6_nd: received icmp packet from non link-local address\n");
+		return 1;
+	}
+
+		/*if (*(uint64_t *)(addr.sin6_addr.s6_addr + 8) != *(uint64_t *)(h->ses->ipv6_addr.s6_addr + 8)) {
+		log_ppp_warn("ipv6_nd: received icmp packet from unknown address\n");
+		continue;
+	}*/
+
+	ipv6_nd_send_ra(h, addr);
+
+	return 0;
+}
+
 static int ipv6_nd_read(struct triton_md_handler_t *_h)
 {
 	struct ipv6_nd_handler_t *h = container_of(_h, typeof(*h), hnd);
@@ -249,27 +282,7 @@ static int ipv6_nd_read(struct triton_md_handler_t *_h)
 			continue;
 		}
 
-		if (n < sizeof(*icmph)) {
-			log_ppp_warn("ipv6_nd: received short icmp packet (%i)\n", n);
-			continue;
-		}
-
-		if (icmph->icmp6_type != ND_ROUTER_SOLICIT) {
-			log_ppp_warn("ipv6_nd: received unexcpected icmp packet (%i)\n", icmph->icmp6_type);
-			continue;
-		}
-
-		if (!IN6_IS_ADDR_LINKLOCAL(&addr.sin6_addr)) {
-			log_ppp_warn("ipv6_nd: received icmp packet from non link-local address\n");
-			continue;
-		}
-
-		/*if (*(uint64_t *)(addr.sin6_addr.s6_addr + 8) != *(uint64_t *)(h->ses->ipv6_addr.s6_addr + 8)) {
-			log_ppp_warn("ipv6_nd: received icmp packet from unknown address\n");
-			continue;
-		}*/
-
-		ipv6_nd_send_ra(h, &addr);
+		ipv6_nd_process_icmp(h, icmph, &addr);
 	}
 
 	mempool_free(icmph);
@@ -277,85 +290,108 @@ static int ipv6_nd_read(struct triton_md_handler_t *_h)
 	return 0;
 }
 
+#ifdef HAVE_SESSION_HOOKS
+__export int ipv6_nd_external_process_icmp(struct ap_session *ses, const void *buf, size_t size, struct in6_addr *addr);
+#endif /* HAVE_SESSION_HOOKS */
+
 static int ipv6_nd_start(struct ap_session *ses)
 {
-	int sock;
+	int sock = -1;
 	struct icmp6_filter filter;
 	struct ipv6_mreq mreq;
 	int val;
 	struct ipv6_nd_handler_t *h;
 
-	net->enter_ns();
-	sock = net->socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
-	net->exit_ns();
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_enable_nd(ses, ipv6_nd_external_process_icmp);
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		net->enter_ns();
+		sock = net->socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+		net->exit_ns();
 
-	if (sock < 0) {
-		log_ppp_error("socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6): %s\n", strerror(errno));
-		return -1;
+		if (sock < 0) {
+			log_ppp_error("socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6): %s\n", strerror(errno));
+			return -1;
+		}
+
+		if (net->setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, ses->ifname, strlen(ses->ifname))) {
+			log_ppp_error("ipv6_nd: setsockopt(SO_BINDTODEVICE): %s\n", strerror(errno));
+			goto out_err;
+		}
+
+		val = 2;
+		if (net->setsockopt(sock, IPPROTO_RAW, IPV6_CHECKSUM, &val, sizeof(val))) {
+			log_ppp_error("ipv6_nd: setsockopt(IPV6_CHECKSUM): %s\n", strerror(errno));
+			goto out_err;
+		}
+
+		val = 255;
+		if (net->setsockopt(sock, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &val, sizeof(val))) {
+			log_ppp_error("ipv6_nd: setsockopt(IPV6_UNICAST_HOPS): %s\n", strerror(errno));
+			goto out_err;
+		}
+
+		if (net->setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &val, sizeof(val))) {
+			log_ppp_error("ipv6_nd: setsockopt(IPV6_MULTICAST_HOPS): %s\n", strerror(errno));
+			goto out_err;
+		}
+
+		/*val = 1;
+		if (setsockopt(sock, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &val, sizeof(val))) {
+			log_ppp_error("ipv6_nd: setsockopt(IPV6_HOPLIMIT): %s\n", strerror(errno));
+			goto out_err;
+		}*/
+
+		ICMP6_FILTER_SETBLOCKALL(&filter);
+		ICMP6_FILTER_SETPASS(ND_ROUTER_SOLICIT, &filter);
+
+		if (net->setsockopt(sock, IPPROTO_ICMPV6, ICMP6_FILTER, &filter, sizeof(filter))) {
+			log_ppp_error("ipv6_nd: setsockopt(ICMP6_FILTER): %s\n", strerror(errno));
+			goto out_err;
+		}
+
+		memset(&mreq, 0, sizeof(mreq));
+		mreq.ipv6mr_interface = ses->ifindex;
+		mreq.ipv6mr_multiaddr.s6_addr32[0] = htonl(0xff020000);
+		mreq.ipv6mr_multiaddr.s6_addr32[3] = htonl(0x2);
+
+		if (net->setsockopt(sock, SOL_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq))) {
+			log_ppp_error("ipv6_nd: failed to join ipv6 allrouters\n");
+			goto out_err;
+		}
+
+		fcntl(sock, F_SETFD, fcntl(sock, F_GETFD) | FD_CLOEXEC);
+
+		net->set_nonblocking(sock, 1);
 	}
-
-	if (net->setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, ses->ifname, strlen(ses->ifname))) {
-		log_ppp_error("ipv6_nd: setsockopt(SO_BINDTODEVICE): %s\n", strerror(errno));
-		goto out_err;
-	}
-
-	val = 2;
-	if (net->setsockopt(sock, IPPROTO_RAW, IPV6_CHECKSUM, &val, sizeof(val))) {
-		log_ppp_error("ipv6_nd: setsockopt(IPV6_CHECKSUM): %s\n", strerror(errno));
-		goto out_err;
-	}
-
-	val = 255;
-	if (net->setsockopt(sock, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &val, sizeof(val))) {
-		log_ppp_error("ipv6_nd: setsockopt(IPV6_UNICAST_HOPS): %s\n", strerror(errno));
-		goto out_err;
-	}
-
-	if (net->setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &val, sizeof(val))) {
-		log_ppp_error("ipv6_nd: setsockopt(IPV6_MULTICAST_HOPS): %s\n", strerror(errno));
-		goto out_err;
-	}
-
-	/*val = 1;
-	if (setsockopt(sock, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &val, sizeof(val))) {
-		log_ppp_error("ipv6_nd: setsockopt(IPV6_HOPLIMIT): %s\n", strerror(errno));
-		goto out_err;
-	}*/
-
-	ICMP6_FILTER_SETBLOCKALL(&filter);
-	ICMP6_FILTER_SETPASS(ND_ROUTER_SOLICIT, &filter);
-
-	if (net->setsockopt(sock, IPPROTO_ICMPV6, ICMP6_FILTER, &filter, sizeof(filter))) {
-		log_ppp_error("ipv6_nd: setsockopt(ICMP6_FILTER): %s\n", strerror(errno));
-		goto out_err;
-	}
-
-	memset(&mreq, 0, sizeof(mreq));
-	mreq.ipv6mr_interface = ses->ifindex;
-	mreq.ipv6mr_multiaddr.s6_addr32[0] = htonl(0xff020000);
-	mreq.ipv6mr_multiaddr.s6_addr32[3] = htonl(0x2);
-
-	if (net->setsockopt(sock, SOL_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq))) {
-		log_ppp_error("ipv6_nd: failed to join ipv6 allrouters\n");
-		goto out_err;
-	}
-
-	fcntl(sock, F_SETFD, fcntl(sock, F_GETFD) | FD_CLOEXEC);
-
-	net->set_nonblocking(sock, 1);
 
 	h = _malloc(sizeof(*h));
 	memset(h, 0, sizeof(*h));
 	h->ses = ses;
 	h->pd.key = &pd_key;
-	h->hnd.fd = sock;
-	h->hnd.read = ipv6_nd_read;
+
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd))
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		h->hnd.fd = sock;
+		h->hnd.read = ipv6_nd_read;
+	}
+
 	h->timer.expire = send_ra_timer;
 	h->timer.period = conf_init_ra_interval * 1000;
 	list_add_tail(&h->pd.entry, &ses->pd_list);
 
-	triton_md_register_handler(ses->ctrl->ctx, &h->hnd);
-	triton_md_enable_handler(&h->hnd, MD_MODE_READ);
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd))
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		triton_md_register_handler(ses->ctrl->ctx, &h->hnd);
+		triton_md_enable_handler(&h->hnd, MD_MODE_READ);
+	}
 
 	triton_timer_add(ses->ctrl->ctx, &h->timer, 0);
 	send_ra_timer(&h->timer);
@@ -378,6 +414,19 @@ static struct ipv6_nd_handler_t *find_pd(struct ap_session *ses)
 
 	return NULL;
 }
+
+#ifdef HAVE_SESSION_HOOKS
+int ipv6_nd_external_process_icmp(struct ap_session *ses, const void *buf, size_t size, struct in6_addr *addr)
+{
+	struct ipv6_nd_handler_t *h = find_pd(ses);
+	struct sockaddr_in6 saddr;
+	memset(&saddr, 0, sizeof(saddr));
+	saddr.sin6_family = AF_INET6;
+	memcpy(&saddr.sin6_addr, addr, sizeof(*addr));
+
+	return ipv6_nd_process_icmp(h, (const struct icmp6_hdr *)buf, &saddr);
+}
+#endif /* HAVE_SESSION_HOOKS */
 
 static void ev_ses_started(struct ap_session *ses)
 {
@@ -404,7 +453,14 @@ static void ev_ses_finishing(struct ap_session *ses)
 	if (h->timer.tpd)
 		triton_timer_del(&h->timer);
 
-	triton_md_unregister_handler(&h->hnd, 1);
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->is_non_socket_dhcpv6_nd) {
+		ipv6layer_unit_disable_nd(ses);
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		triton_md_unregister_handler(&h->hnd, 1);
+	}
 
 	list_del(&h->pd.entry);
 

--- a/accel-pppd/ipv6/ppp_ipv6layer.c
+++ b/accel-pppd/ipv6/ppp_ipv6layer.c
@@ -1,0 +1,291 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
+#include <netinet/udp.h>
+
+#include "ppp.h"
+#include "triton.h"
+#include "ap_session.h"
+#include "ipdb.h"
+#include "log.h"
+
+#include "memdebug.h"
+
+static const unsigned short sc_dhcpv6_client_port = 546;
+static const unsigned short sc_dhcpv6_serv_port = 547;
+
+/* from dhcpv6.c */
+extern int dhcpv6_external_process_udp(struct ap_session *ses, const void *buf, size_t n, struct in6_addr *addr, unsigned short port);
+
+/* from nd.c */
+extern int ipv6_nd_external_process_icmp(struct ap_session *ses, const void *buf, size_t size, struct in6_addr *addr);
+
+void ppp_unit_ipv6_recv(struct ppp_handler_t *h);
+void ppp_unit_ipv6_recv_proto_rej(struct ppp_handler_t *h);
+
+
+static void *pd_key;
+
+struct ipv6layer_pd {
+	struct ap_private pd;
+	struct ap_session *ses;
+	struct ppp_handler_t vpp_ipv6_hnd;
+	uint8_t is_recv_dhcpv6_enabled;
+	uint8_t is_recv_nd_enabled;
+};
+
+static struct ipv6layer_pd *find_pd(struct ap_session *ses)
+{
+	struct ap_private *pd;
+
+	list_for_each_entry(pd, &ses->pd_list, entry) {
+		if (pd->key == &pd_key)
+			return container_of(pd, struct ipv6layer_pd, pd);
+	}
+
+	return NULL;
+}
+
+void ipv6layer_add_unit_layer(struct ap_session *ses, struct ipv6layer_pd *pd)
+{
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+
+	pd->vpp_ipv6_hnd.proto = PPP_IPV6;
+	pd->vpp_ipv6_hnd.recv = ppp_unit_ipv6_recv;
+	pd->vpp_ipv6_hnd.recv_proto_rej = ppp_unit_ipv6_recv_proto_rej;
+
+	ppp_register_unit_handler(ppp, &pd->vpp_ipv6_hnd);
+}
+
+void ipv6layer_del_unit_layer(struct ap_session *ses, struct ipv6layer_pd *pd)
+{
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+	ppp_unregister_handler(ppp, &pd->vpp_ipv6_hnd);
+}
+
+__export void ipv6layer_unit_enable_nd(struct ap_session *ses, int (*nd_recv)(struct ap_session *, const void *, size_t, struct in6_addr *))
+{
+	struct ipv6layer_pd *pd = find_pd(ses);
+	if (pd == NULL) {
+		pd = _malloc(sizeof(*pd));
+		memset(pd, 0, sizeof(*pd));
+
+		pd->pd.key = &pd_key;
+		list_add_tail(&pd->pd.entry, &ses->pd_list);
+
+		pd->ses = ses;
+	}
+
+	if (!pd->is_recv_dhcpv6_enabled && !pd->is_recv_nd_enabled)
+		ipv6layer_add_unit_layer(ses, pd);
+
+	pd->is_recv_nd_enabled = 1;
+}
+
+__export void ipv6layer_unit_disable_nd(struct ap_session *ses)
+{
+	struct ipv6layer_pd *pd = find_pd(ses);
+	if (pd == NULL)
+		return;
+
+	pd->is_recv_nd_enabled = 0;
+
+	if (!pd->is_recv_dhcpv6_enabled && !pd->is_recv_nd_enabled) {
+		ipv6layer_del_unit_layer(ses, pd);
+
+		list_del(&pd->pd.entry);
+		_free(pd);
+	}
+}
+
+__export void ipv6layer_unit_enable_dhcpv6(struct ap_session *ses, int (*dhcpv6_recv)(struct ap_session *, const void *, size_t, struct in6_addr *, unsigned short))
+{
+	struct ipv6layer_pd *pd = find_pd(ses);
+	if (pd == NULL) {
+		pd = _malloc(sizeof(*pd));
+		memset(pd, 0, sizeof(*pd));
+
+		pd->pd.key = &pd_key;
+		list_add_tail(&pd->pd.entry, &ses->pd_list);
+
+		pd->ses = ses;
+	};
+
+	if (!pd->is_recv_dhcpv6_enabled && !pd->is_recv_nd_enabled)
+		ipv6layer_add_unit_layer(ses, pd);
+
+	pd->is_recv_dhcpv6_enabled = 1;
+}
+
+__export void ipv6layer_unit_disable_dhcpv6(struct ap_session *ses)
+{
+	struct ipv6layer_pd *pd = find_pd(ses);
+	if (pd == NULL)
+		return;
+
+	pd->is_recv_dhcpv6_enabled = 0;
+
+	if (!pd->is_recv_dhcpv6_enabled && !pd->is_recv_nd_enabled) {
+		ipv6layer_del_unit_layer(ses, pd);
+
+		list_del(&pd->pd.entry);
+		_free(pd);
+	}
+}
+
+static inline uint32_t partial_csum(uint32_t sum, const uint16_t *buf, int len)
+{
+	for (; len > 1;) {
+		sum += *buf++;
+		len -= 2;
+	}
+
+	if (len == 1) {
+		sum += *((const uint8_t *)buf);
+	}
+
+	return sum;
+}
+
+static inline uint16_t finish_csum(uint32_t sum)
+{
+	sum = (sum >> 16) + (sum & 0xffff);
+	sum += (sum >> 16);
+
+	return (uint16_t)(~sum);
+}
+
+static inline uint16_t ipv6_calc_csum(uint8_t proto, const void *buf, uint32_t len,
+							   struct in6_addr *src, struct in6_addr *dst)
+{
+	uint32_t sum = 0;
+	struct
+	{
+		struct in6_addr src;
+		struct in6_addr dst;
+		uint32_t plen;
+		uint8_t zeros[3];
+		uint8_t next_header;
+	} pseudo_hdr;
+
+	memset(&pseudo_hdr, 0, sizeof(pseudo_hdr));
+	pseudo_hdr.src = *src;
+	pseudo_hdr.dst = *dst;
+	pseudo_hdr.plen = htonl(len);
+	pseudo_hdr.next_header = proto;
+
+	sum = partial_csum(sum, (const uint16_t *)&pseudo_hdr, sizeof(pseudo_hdr));
+	sum = partial_csum(sum, (const uint16_t *)buf, len);
+
+	return finish_csum(sum);
+}
+
+__export void ipv6layer_unit_icmpv6_send(struct ap_session *ses, const void *buf, size_t size, struct sockaddr *addr, socklen_t addrlen)
+{
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+	size_t send_size = size + sizeof(struct ip6_hdr) + 2;
+	unsigned char send_buf[2048];
+	struct ip6_hdr *ip6 = (struct ip6_hdr *)(send_buf + 2);
+	struct icmp6_hdr *icmp6 = (struct icmp6_hdr *)(ip6 + 1);
+
+	if (send_size > 2048) {
+		log_warn("VPP_IPV6_ICMP: Issue while sending ICMPv6 packet - the packet is too big - size: %ld", send_size);
+		return;
+	}
+
+	*(unsigned short *)(send_buf) = htons(PPP_IPV6);
+
+	/* fill ipv6 */
+	memset(ip6, 0, sizeof(*ip6));
+	ip6->ip6_flow = htonl(0x60000000);
+	ip6->ip6_plen = htons(size);
+	ip6->ip6_nxt = IPPROTO_ICMPV6;
+	ip6->ip6_hlim = 0xff;
+	memcpy(&ip6->ip6_dst, &((struct sockaddr_in6 *)(addr))->sin6_addr, sizeof(struct in6_addr));
+	if (ses->ipv6 != NULL) {
+		ip6->ip6_src.s6_addr32[0] = htonl(0xfe800000);
+		*(uint64_t *)(ip6->ip6_src.s6_addr + 8) = ses->ipv6->intf_id;
+	}
+
+	memcpy(icmp6, buf, size);
+
+	/* calculate crc */
+	icmp6->icmp6_cksum = ipv6_calc_csum(IPPROTO_ICMPV6, icmp6, size, &ip6->ip6_src, &ip6->ip6_dst);
+
+	ppp_unit_send(ppp, send_buf, send_size);
+}
+
+__export void ipv6layer_unit_dhcpv6_send(struct ap_session *ses, const void *buf, size_t size, struct sockaddr *addr, socklen_t addrlen)
+{
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+	size_t send_size = size + sizeof(struct udphdr) + sizeof(struct ip6_hdr) + 2;
+	unsigned char send_buf[2048];
+	struct ip6_hdr *ip6 = (struct ip6_hdr *)(send_buf + 2);
+	struct udphdr *udp = (struct udphdr *)(ip6 + 1);
+
+	if (send_size > 2048) {
+		log_warn("IPV6_DHCP: Issue while sending DHCPv6 packet - the packet is too big - size: %ld", send_size);
+		return;
+	}
+
+	*(unsigned short *)(send_buf) = htons(PPP_IPV6);
+
+	/* fill ipv6 */
+	memset(ip6, 0, sizeof(*ip6));
+	ip6->ip6_flow = htonl(0x60000000);
+	ip6->ip6_plen = htons(size + sizeof(struct udphdr));
+	ip6->ip6_nxt = IPPROTO_UDP;
+	ip6->ip6_hlim = 0x01;
+	memcpy(&ip6->ip6_dst, &((struct sockaddr_in6 *)(addr))->sin6_addr, sizeof(struct in6_addr));
+	if (ses->ipv6 != NULL) {
+		ip6->ip6_src.s6_addr32[0] = htonl(0xfe800000);
+		*(uint64_t *)(ip6->ip6_src.s6_addr + 8) = ses->ipv6->intf_id;
+	}
+
+	/* fill udp */
+	udp->source = htons(sc_dhcpv6_serv_port);
+	udp->dest = ((struct sockaddr_in6 *)(addr))->sin6_port;
+	udp->len = htons(size + sizeof(struct udphdr));
+	udp->check = 0;
+
+	memcpy(udp + 1, buf, size);
+
+	udp->check = ipv6_calc_csum(IPPROTO_UDP, udp, size + sizeof(struct udphdr), &ip6->ip6_src, &ip6->ip6_dst);
+
+	ppp_unit_send(ppp, send_buf, send_size);
+}
+
+void ppp_unit_ipv6_recv(struct ppp_handler_t *ppp_h)
+{
+	struct ip6_hdr *ip6 = NULL;
+	struct ipv6layer_pd *pd = container_of(ppp_h, typeof(*pd), vpp_ipv6_hnd);
+	struct ppp_t *ppp = container_of(pd->ses, typeof(*ppp), ses);
+
+	if (pd == NULL)
+		return;
+
+	ip6 = (struct ip6_hdr *)((unsigned char *)(ppp->buf) + 2);
+	if (ip6->ip6_nxt == IPPROTO_ICMPV6 && pd->is_recv_nd_enabled) {
+		struct icmp6_hdr *icmp6 = (struct icmp6_hdr *)(ip6 + 1);
+		if (icmp6->icmp6_type == ND_ROUTER_SOLICIT) {
+			/* nd routine */
+			ipv6_nd_external_process_icmp(&ppp->ses, icmp6, ppp->buf_size - sizeof(*ip6) - 2, &ip6->ip6_src);
+		}
+	}
+	else if (ip6->ip6_nxt == IPPROTO_UDP && pd->is_recv_dhcpv6_enabled) {
+		struct udphdr *udp = (struct udphdr *)(ip6 + 1);
+		if (udp->source == htons(sc_dhcpv6_client_port) && udp->dest == htons(sc_dhcpv6_serv_port)) {
+			/* dhcpd6 routine */
+			dhcpv6_external_process_udp(&ppp->ses, udp + 1, ppp->buf_size - sizeof(*udp) - sizeof(*ip6) - 2, &ip6->ip6_src, udp->source);
+		}
+	}
+}
+
+void ppp_unit_ipv6_recv_proto_rej(struct ppp_handler_t *h)
+{
+}

--- a/accel-pppd/ipv6/ppp_ipv6layer.h
+++ b/accel-pppd/ipv6/ppp_ipv6layer.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#ifndef VPPIPV6LAYER_H
+#define VPPIPV6LAYER_H
+
+void ipv6layer_unit_enable_nd(struct ap_session *ses, int (*nd_recv)(struct ap_session *, const void *, size_t, struct in6_addr *));
+void ipv6layer_unit_disable_nd(struct ap_session *ses);
+
+void ipv6layer_unit_enable_dhcpv6(struct ap_session *ses, int (*dhcpv6_recv)(struct ap_session *, const void *, size_t, struct in6_addr *, unsigned short));
+void ipv6layer_unit_disable_dhcpv6(struct ap_session *ses);
+
+void ipv6layer_unit_icmpv6_send(struct ap_session *ses, const void *buf, size_t size, struct sockaddr *addr, socklen_t addrlen);
+void ipv6layer_unit_dhcpv6_send(struct ap_session *ses, const void *buf, size_t size, struct sockaddr *addr, socklen_t addrlen);
+
+#endif /* VPPIPV6LAYER_H */

--- a/accel-pppd/libnetlink/new_link_event.c
+++ b/accel-pppd/libnetlink/new_link_event.c
@@ -1,0 +1,180 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include <linux/if.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "triton.h"
+#include "ap_net.h"
+
+#include "new_link_event.h"
+
+static struct rtnl_handle rth;
+static struct triton_context_t ctx;
+static struct triton_md_handler_t hnd;
+
+LIST_HEAD(nnle_handlers);
+
+static void nnle_emit_callbacks(const char *name, int is_add)
+{
+	struct nnle_handler_t *e;
+	list_for_each_entry(e, &nnle_handlers, entry) {
+		if (is_add) {
+			e->on_new_link(name);
+		} else {
+			e->on_del_link(name);
+		}
+	}
+}
+
+static int nnle_nlmsg_handler(const struct sockaddr_nl *nladdr,
+		      struct nlmsghdr *hdr)
+{
+	struct rtattr *tb[IFLA_MAX+1];
+	struct ifinfomsg *ifi;
+	char ifname[IFNAMSIZ] = {0};
+
+	ifi = NLMSG_DATA(hdr);
+
+	parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), hdr->nlmsg_len - NLMSG_LENGTH(sizeof(struct ifinfomsg)));
+
+	if (tb[IFLA_IFNAME] && strlen(RTA_DATA(tb[IFLA_IFNAME])) < IFNAMSIZ)
+		strncpy(ifname, RTA_DATA(tb[IFLA_IFNAME]), IFNAMSIZ - 1);
+
+	if (hdr->nlmsg_type == RTM_NEWLINK && *(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) == IF_OPER_DOWN) {
+
+		struct ifreq ifr;
+		memset(&ifr, 0, sizeof(ifr));
+		strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+
+		net->sock_ioctl(SIOCGIFFLAGS, &ifr);
+		if (ifr.ifr_flags) {
+			ifr.ifr_flags |= IFF_UP;
+			net->sock_ioctl(SIOCSIFFLAGS, &ifr);
+		}
+	}
+
+	if (hdr->nlmsg_type == RTM_NEWLINK && *(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) == IF_OPER_UP) {
+		nnle_emit_callbacks(ifname, 1);
+	} else if (hdr->nlmsg_type == RTM_DELLINK) {
+		nnle_emit_callbacks(ifname, 0);
+	}
+
+	return 0;
+}
+
+static int nnle_read(struct triton_md_handler_t *th)
+{
+	int status;
+	struct nlmsghdr* h;
+	struct sockaddr_nl nladdr;
+	struct iovec iov;
+	struct msghdr msg = {
+		.msg_name = &nladdr,
+		.msg_namelen = sizeof(nladdr),
+		.msg_iov = &iov,
+	.msg_iovlen = 1,
+	};
+	char buf[8192];
+
+	memset(&nladdr, 0, sizeof(nladdr));
+	nladdr.nl_family = AF_NETLINK;
+	nladdr.nl_pid = 0;
+	nladdr.nl_groups = 0;
+
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	for (;;) {
+		status = recvmsg(rth.fd, &msg, 0);
+
+		if (status <= 0) {
+			if (errno == EINTR || errno == EAGAIN)
+				break;
+			return -1;
+		}
+
+		if (msg.msg_namelen != sizeof(nladdr))
+			return -1;
+
+		for (h = (struct nlmsghdr*)buf; status >= sizeof(*h);) {
+			int err;
+			int len = h->nlmsg_len;
+			int l = len - sizeof(*h);
+
+			if (l < 0 || len > status)
+				return -1;
+
+			err = nnle_nlmsg_handler(&nladdr, h);
+			if (err < 0)
+				return err;
+
+			status -= NLMSG_ALIGN(len);
+			h = (struct nlmsghdr*)((char*)h + NLMSG_ALIGN(len));
+		}
+
+		if (status)
+			return -1;
+	}
+
+	return 0;
+}
+
+static void nnle_close(struct triton_context_t *ctx)
+{
+	triton_md_disable_handler(&hnd, MD_MODE_READ);
+	triton_md_unregister_handler(&hnd, 1);
+	triton_context_unregister(ctx);
+}
+
+static void nnle_free(struct triton_context_t *ctx)
+{
+	triton_md_disable_handler(&hnd, MD_MODE_READ);
+	triton_md_unregister_handler(&hnd, 1);
+	triton_context_unregister(ctx);
+}
+
+static void nnle_ctx_switch(struct triton_context_t *ctx, void *arg)
+{
+	net = def_net;
+}
+
+__export void nnle_add_handler(struct nnle_handler_t *h) {
+	list_add(&h->entry, &nnle_handlers);
+}
+
+__export void nnle_del_handler(struct nnle_handler_t *h) {
+	list_del(&h->entry);
+}
+
+static void nnle_init()
+{
+	if (rtnl_open_byproto(&rth, 1 << (RTNLGRP_LINK - 1), NETLINK_ROUTE)) {
+		rth.fd = -1;
+		return;
+	}
+
+	fcntl(rth.fd, F_SETFL, O_NONBLOCK);
+	fcntl(rth.fd, F_SETFD, fcntl(rth.fd, F_GETFD) | FD_CLOEXEC);
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&hnd, 0, sizeof(hnd));
+
+	ctx.close = nnle_close;
+	ctx.free = nnle_free;
+	ctx.before_switch = nnle_ctx_switch;
+	triton_context_register(&ctx, NULL);
+	hnd.fd = rth.fd;
+	hnd.read = nnle_read;
+	triton_md_register_handler(&ctx, &hnd);
+	triton_md_enable_handler(&hnd, MD_MODE_READ);
+	triton_context_wakeup(&ctx);
+}
+
+DEFINE_INIT(20, nnle_init);

--- a/accel-pppd/ppp/ppp.c
+++ b/accel-pppd/ppp/ppp.c
@@ -57,6 +57,7 @@ static mempool_t uc_pool;
 
 static int ppp_chan_read(struct triton_md_handler_t*);
 static int ppp_unit_read(struct triton_md_handler_t*);
+static int ppp_chan_and_unit_read(struct triton_md_handler_t*);
 static int init_layers(struct ppp_t *);
 static void _free_layers(struct ppp_t *);
 static void start_first_layer(struct ppp_t *);
@@ -71,6 +72,7 @@ void __export ppp_init(struct ppp_t *ppp)
 	ppp->fd = -1;
 	ppp->chan_fd = -1;
 	ppp->unit_fd = -1;
+	ppp->is_unit_read_enabled = 0;
 
 	ap_session_init(&ppp->ses);
 }
@@ -80,25 +82,34 @@ int __export establish_ppp(struct ppp_t *ppp)
 	if (ap_shutdown)
 		return -1;
 
-	/* Open an instance of /dev/ppp and connect the channel to it */
-	if (net->ppp_ioctl(ppp->fd, PPPIOCGCHAN, &ppp->chan_idx) == -1) {
-		log_ppp_error("ioctl(PPPIOCGCHAN): %s\n", strerror(errno));
-		return -1;
-	}
+#ifdef HAVE_SESSION_HOOKS
+	if (ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp) {
+		/* use fd as chan_fd mostly for sending chan packets */
+		ppp->chan_fd = ppp->fd;
+		net->set_nonblocking(ppp->fd, 1);
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		/* Open an instance of /dev/ppp and connect the channel to it */
+		if (net->ppp_ioctl(ppp->fd, PPPIOCGCHAN, &ppp->chan_idx) == -1) {
+			log_ppp_error("ioctl(PPPIOCGCHAN): %s\n", strerror(errno));
+			return -1;
+		}
 
-	ppp->chan_fd = net->ppp_open();
-	if (ppp->chan_fd < 0) {
-		log_ppp_error("open(chan) /dev/ppp: %s\n", strerror(errno));
-		return -1;
-	}
+		ppp->chan_fd = net->ppp_open();
+		if (ppp->chan_fd < 0) {
+			log_ppp_error("open(chan) /dev/ppp: %s\n", strerror(errno));
+			return -1;
+		}
 
-	fcntl(ppp->chan_fd, F_SETFD, fcntl(ppp->chan_fd, F_GETFD) | FD_CLOEXEC);
+		fcntl(ppp->chan_fd, F_SETFD, fcntl(ppp->chan_fd, F_GETFD) | FD_CLOEXEC);
 
-	net->set_nonblocking(ppp->chan_fd, 1);
+		net->set_nonblocking(ppp->chan_fd, 1);
 
-	if (net->ppp_ioctl(ppp->chan_fd, PPPIOCATTCHAN, &ppp->chan_idx) < 0) {
-		log_ppp_error("ioctl(PPPIOCATTCHAN): %s\n", strerror(errno));
-		goto exit_close_chan;
+		if (net->ppp_ioctl(ppp->chan_fd, PPPIOCATTCHAN, &ppp->chan_idx) < 0) {
+			log_ppp_error("ioctl(PPPIOCATTCHAN): %s\n", strerror(errno));
+			goto exit_close_chan;
+		}
 	}
 
 	if (init_layers(ppp))
@@ -109,7 +120,14 @@ int __export establish_ppp(struct ppp_t *ppp)
 	}
 
 	ppp->chan_hnd.fd = ppp->chan_fd;
-	ppp->chan_hnd.read = ppp_chan_read;
+
+#ifdef HAVE_SESSION_HOOKS
+	/* Use combined read for non-dev-ppp */
+	if (ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp)
+		ppp->chan_hnd.read = ppp_chan_and_unit_read;
+	else
+#endif /* HAVE_SESSION_HOOKS */
+		ppp->chan_hnd.read = ppp_chan_read;
 
 	if (conf_unit_preallocate) {
 		if (connect_ppp_channel(ppp))
@@ -128,7 +146,13 @@ int __export establish_ppp(struct ppp_t *ppp)
 	return 0;
 
 exit_close_chan:
-	close(ppp->chan_fd);
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp))
+#endif /* HAVE_SESSION_HOOKS */
+		close(ppp->chan_fd);
+
+	ppp->chan_fd = -1;
+	ppp->chan_hnd.fd = -1;
 
 	return -1;
 }
@@ -139,20 +163,34 @@ int __export connect_ppp_channel(struct ppp_t *ppp)
 	struct ifreq ifr;
 
 	if (ppp->unit_fd != -1) {
-		if (setup_ppp_mru(ppp))
+		if (
+#ifdef HAVE_SESSION_HOOKS
+			!(ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp) &&
+#endif /* HAVE_SESSION_HOOKS */
+			setup_ppp_mru(ppp))
 			goto exit_close_unit;
 		return 0;
 	}
 
-	pthread_mutex_lock(&uc_lock);
-	if (!list_empty(&uc_list)) {
-		uc = list_entry(uc_list.next, typeof(*uc), entry);
-		list_del(&uc->entry);
-		--uc_size;
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp))
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		pthread_mutex_lock(&uc_lock);
+		if (!list_empty(&uc_list)) {
+			uc = list_entry(uc_list.next, typeof(*uc), entry);
+			list_del(&uc->entry);
+			--uc_size;
+		}
+		pthread_mutex_unlock(&uc_lock);
 	}
-	pthread_mutex_unlock(&uc_lock);
 
-	if (uc) {
+#ifdef HAVE_SESSION_HOOKS
+	if (ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp) {
+		ppp->unit_fd = ppp->fd;
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	 if (uc) {
 		ppp->unit_fd = uc->fd;
 		ppp->ses.unit_idx = uc->unit_idx;
 		mempool_free(uc);
@@ -176,47 +214,59 @@ int __export connect_ppp_channel(struct ppp_t *ppp)
 		}
 	}
 
-	if (net->ppp_ioctl(ppp->chan_fd, PPPIOCCONNECT, &ppp->ses.unit_idx) < 0) {
-		log_ppp_error("ioctl(PPPIOCCONNECT): %s\n", strerror(errno));
-		goto exit_close_unit;
+#ifdef HAVE_SESSION_HOOKS
+	if (ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp) {
+		ppp->ses.ifindex = -1;
+		ppp->is_unit_read_enabled = 1;
+	} else
+#endif /* HAVE_SESSION_HOOKS */
+	{
+		if (net->ppp_ioctl(ppp->chan_fd, PPPIOCCONNECT, &ppp->ses.unit_idx) < 0) {
+			log_ppp_error("ioctl(PPPIOCCONNECT): %s\n", strerror(errno));
+			goto exit_close_unit;
+		}
+
+		sprintf(ppp->ses.ifname, "ppp%i", ppp->ses.unit_idx);
+
+		log_ppp_info1("connect: %s <--> %s(%s)\n", ppp->ses.ifname, ppp->ses.ctrl->name, ppp->ses.chan_name);
+
+		memset(&ifr, 0, sizeof(ifr));
+		strcpy(ifr.ifr_name, ppp->ses.ifname);
+		if (net->sock_ioctl(SIOCGIFINDEX, &ifr)) {
+			log_ppp_error("ioctl(SIOCGIFINDEX): %s\n", strerror(errno));
+			goto exit_close_unit;
+		}
+		ppp->ses.ifindex = ifr.ifr_ifindex;
+
+		setup_ppp_mru(ppp);
+
+		ap_session_set_ifindex(&ppp->ses);
+
+		ppp->unit_hnd.fd = ppp->unit_fd;
+		ppp->unit_hnd.read = ppp_unit_read;
+
+		log_ppp_debug("ppp connected\n");
+
+		triton_md_register_handler(ppp->ses.ctrl->ctx, &ppp->unit_hnd);
+		triton_md_enable_handler(&ppp->unit_hnd, MD_MODE_READ);
 	}
-
-	sprintf(ppp->ses.ifname, "ppp%i", ppp->ses.unit_idx);
-
-	log_ppp_info1("connect: %s <--> %s(%s)\n", ppp->ses.ifname, ppp->ses.ctrl->name, ppp->ses.chan_name);
-
-	memset(&ifr, 0, sizeof(ifr));
-	strcpy(ifr.ifr_name, ppp->ses.ifname);
-	if (net->sock_ioctl(SIOCGIFINDEX, &ifr)) {
-		log_ppp_error("ioctl(SIOCGIFINDEX): %s\n", strerror(errno));
-		goto exit_close_unit;
-	}
-	ppp->ses.ifindex = ifr.ifr_ifindex;
-
-	setup_ppp_mru(ppp);
-
-	ap_session_set_ifindex(&ppp->ses);
-
-	ppp->unit_hnd.fd = ppp->unit_fd;
-	ppp->unit_hnd.read = ppp_unit_read;
-
-	log_ppp_debug("ppp connected\n");
-
-	triton_md_register_handler(ppp->ses.ctrl->ctx, &ppp->unit_hnd);
-	triton_md_enable_handler(&ppp->unit_hnd, MD_MODE_READ);
 
 	return 0;
 
 exit_close_unit:
-	close(ppp->unit_fd);
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp))
+#endif /* HAVE_SESSION_HOOKS */
+		close(ppp->unit_fd);
 	ppp->unit_fd = -1;
 exit:
 	return -1;
 }
 
-static void destroy_ppp_channel(struct ppp_t *ppp)
+static void destroy_ppp_channel(struct ppp_t *ppp, int is_non_dev)
 {
-	triton_md_unregister_handler(&ppp->chan_hnd, 1);
+	/* do not close chan_hnd.fd if its non-dev-ppp(chan_hnd.fd == ppp.fd) */
+	triton_md_unregister_handler(&ppp->chan_hnd, !is_non_dev);
 	close(ppp->fd);
 	ppp->fd = -1;
 	ppp->chan_fd = -1;
@@ -259,12 +309,23 @@ static int setup_ppp_mru(struct ppp_t *ppp)
 static void destablish_ppp(struct ppp_t *ppp)
 {
 	struct pppunit_cache *uc = NULL;
+	int is_non_dev_ppp = 0;
+#ifdef HAVE_SESSION_HOOKS
+	is_non_dev_ppp = ppp->ses.hooks && ppp->ses.hooks->is_non_dev_ppp;
+#endif /* HAVE_SESSION_HOOKS */
 
 	if (ppp->unit_fd < 0) {
 		ap_session_finished(&ppp->ses);
-		destroy_ppp_channel(ppp);
+		destroy_ppp_channel(ppp, is_non_dev_ppp);
 		return;
 	}
+
+#ifdef HAVE_SESSION_HOOKS
+	if (is_non_dev_ppp) {
+		ppp->is_unit_read_enabled = 0;
+		goto skip;
+	}
+#endif /* HAVE_SESSION_HOOKS */
 
 	if (conf_unit_cache) {
 		struct ifreq ifr;
@@ -306,11 +367,15 @@ skip:
 
 	ppp->unit_fd = -1;
 
-	destroy_ppp_channel(ppp);
+	destroy_ppp_channel(ppp, is_non_dev_ppp);
 
 	log_ppp_debug("ppp destablished\n");
 
-	if (uc) {
+	if (
+#ifdef HAVE_SESSION_HOOKS
+		!is_non_dev_ppp &&
+#endif /* HAVE_SESSION_HOOKS */
+		 uc) {
 		pthread_mutex_lock(&uc_lock);
 		list_add_tail(&uc->entry, &uc_list);
 		if (++uc_size > conf_unit_cache)
@@ -485,6 +550,73 @@ cont:
 		}
 		lcp_send_proto_rej(ppp, proto);
 		//log_ppp_warn("ppp_unit_read: discarding unknown packet %x\n", proto);
+	}
+
+	mempool_free(ppp->buf);
+	ppp->buf = NULL;
+
+	return 0;
+}
+
+static int ppp_chan_and_unit_read(struct triton_md_handler_t *h) {
+	struct ppp_t *ppp = container_of(h, typeof(*ppp), chan_hnd);
+	struct ppp_handler_t *ppp_h;
+	uint16_t proto;
+
+	if (!ppp->buf)
+		ppp->buf = mempool_alloc(buf_pool);
+
+	while(1) {
+cont:
+		ppp->buf_size = net->read(h->fd, ppp->buf, PPP_BUF_SIZE);
+		if (ppp->buf_size < 0) {
+			if (errno != EAGAIN) {
+				log_ppp_error("ppp_chan_and_unit_read: %s\n", strerror(errno));
+				ap_session_terminate(&ppp->ses, TERM_NAS_ERROR, 1);
+				return 1;
+			}
+			break;
+		}
+
+		if (ppp->buf_size == 0)
+			break;
+
+		if (ppp->buf_size < 2) {
+			log_ppp_error("ppp_chan_and_unit_read: short read %i\n", ppp->buf_size);
+			continue;
+		}
+
+		proto = ntohs(*(uint16_t*)ppp->buf);
+		list_for_each_entry(ppp_h, &ppp->chan_handlers, entry) {
+			if (ppp_h->proto == proto) {
+				ppp_h->recv(ppp_h);
+				if (ppp->fd == -1) {
+					ppp->ses.ctrl->finished(&ppp->ses);
+					return 1;
+				}
+				goto cont;
+			}
+		}
+
+		if (ppp->is_unit_read_enabled > 0) {
+			list_for_each_entry(ppp_h, &ppp->unit_handlers, entry) {
+				if (ppp_h->proto == proto) {
+					ppp_h->recv(ppp_h);
+					if (ppp->fd == -1) {
+						ppp->ses.ctrl->finished(&ppp->ses);
+						return 1;
+					}
+					goto cont;
+				}
+			}
+		}
+
+		/* For VPP, clients' IPv6 packets would come through ppp socket,
+		   the handler may not be installed(g.e, because of a configuration).
+		   Doesn't require sending "reject" in this case. */
+		if (proto != PPP_IPV6)
+			lcp_send_proto_rej(ppp, proto);
+		// log_ppp_warn("ppp_chan_and_unit_read: discarding unknown packet %x\n", proto);
 	}
 
 	mempool_free(ppp->buf);

--- a/accel-pppd/ppp/ppp.h
+++ b/accel-pppd/ppp/ppp.h
@@ -61,6 +61,13 @@ struct ppp_t
 	struct list_head unit_handlers;
 
 	struct list_head layers;
+
+	/**
+	 * In non-dev-ppp environment, channel and unit reads would be performed
+	 * through the same socket and will use the same handler/function.
+	 * This flag sets that additionally unit handlers would be used.
+	 */
+	int is_unit_read_enabled;
 };
 
 struct ppp_layer_t;

--- a/accel-pppd/ppp/ppp_ccp.c
+++ b/accel-pppd/ppp/ppp_ccp.c
@@ -139,7 +139,10 @@ int ccp_layer_start(struct ppp_layer_data_t *ld)
 
 	log_ppp_debug("ccp_layer_start\n");
 
-	ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ccp->ppp->ses.hooks && ccp->ppp->ses.hooks->is_non_dev_ppp))
+#endif /* HAVE_SESSION_HOOKS */
+		ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
 
 	if (list_empty(&ccp->options) || !conf_ccp) {
 		ccp->started = 1;
@@ -155,7 +158,11 @@ int ccp_layer_start(struct ppp_layer_data_t *ld)
 			return -1;
 	}
 
-	if (ccp_set_flags(ccp->ppp->unit_fd, 1, 0)) {
+	if (
+#ifdef HAVE_SESSION_HOOKS
+		!(ccp->ppp->ses.hooks && ccp->ppp->ses.hooks->is_non_dev_ppp) &&
+#endif /* HAVE_SESSION_HOOKS */
+		 ccp_set_flags(ccp->ppp->unit_fd, 1, 0)) {
 		ppp_fsm_close(&ccp->fsm);
 		return -1;
 	}
@@ -169,7 +176,10 @@ void ccp_layer_finish(struct ppp_layer_data_t *ld)
 
 	log_ppp_debug("ccp_layer_finish\n");
 
-	ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
+#ifdef HAVE_SESSION_HOOKS
+	if (!(ccp->ppp->ses.hooks && ccp->ppp->ses.hooks->is_non_dev_ppp))
+#endif /* HAVE_SESSION_HOOKS */
+		ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
 
 	ccp->fsm.fsm_state = FSM_Closed;
 
@@ -197,7 +207,11 @@ static void ccp_layer_up(struct ppp_fsm_t *fsm)
 	if (!ccp->started) {
 		log_ppp_debug("ccp_layer_started\n");
 		ccp->started = 1;
-		if (ccp_set_flags(ccp->ppp->unit_fd, 1, 1)) {
+		if (
+#ifdef HAVE_SESSION_HOOKS
+			!(ccp->ppp->ses.hooks && ccp->ppp->ses.hooks->is_non_dev_ppp) &&
+#endif /* HAVE_SESSION_HOOKS */
+			 ccp_set_flags(ccp->ppp->unit_fd, 1, 1)) {
 			ap_session_terminate(&ccp->ppp->ses, TERM_NAS_ERROR, 0);
 			return;
 		}

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -25,6 +25,8 @@
 
 #include "memdebug.h"
 
+#include "accel_iputils.h"
+
 int conf_max_try = 3;
 int conf_timeout = 3;
 int conf_acct_timeout = 3;
@@ -854,7 +856,7 @@ static void ses_started(struct ap_session *ses)
 		bool gw_spec = !IN6_IS_ADDR_UNSPECIFIED(&fr6->gw);
 		char nbuf[INET6_ADDRSTRLEN];
 		char gwbuf[INET6_ADDRSTRLEN];
-		if (ip6route_add(gw_spec ? 0 : rpd->ses->ifindex, &fr6->prefix, fr6->plen, gw_spec ? &fr6->gw : NULL, 3, fr6->prio, rpd->ses->vrf_name)) {
+		if (accel_ip6route_add(ses, gw_spec ? 0 : rpd->ses->ifindex, &fr6->prefix, fr6->plen, gw_spec ? &fr6->gw : NULL, 3, fr6->prio, rpd->ses->vrf_name)) {
 			log_ppp_warn("radius: failed to add route %s/%hhu %s %u\n",
 				     u_ip6str(&fr6->prefix, nbuf), fr6->plen,
 				     u_ip6str(&fr6->gw, gwbuf), fr6->prio);
@@ -862,7 +864,7 @@ static void ses_started(struct ap_session *ses)
 	}
 
 	for (fr = rpd->fr; fr; fr = fr->next) {
-		if (iproute_add(fr->gw ? 0 : rpd->ses->ifindex, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name)) {
+		if (accel_iproute_add(ses, fr->gw ? 0 : rpd->ses->ifindex, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name)) {
 			char dst[17], gw[17];
 			u_inet_ntoa(fr->dst, dst);
 			u_inet_ntoa(fr->gw, gw);
@@ -901,12 +903,12 @@ static void ses_finishing(struct ap_session *ses)
 		 * when the interface is removed.
 		 */
 		if (!IN6_IS_ADDR_UNSPECIFIED(&fr6->gw))
-			ip6route_del(0, &fr6->prefix, fr6->plen, &fr6->gw, 3, fr6->prio, rpd->ses->vrf_name);
+			accel_ip6route_del(ses, 0, &fr6->prefix, fr6->plen, &fr6->gw, 3, fr6->prio, rpd->ses->vrf_name);
 	}
 
 	for (fr = rpd->fr; fr; fr = fr->next) {
 		if (fr->gw)
-			iproute_del(0, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name);
+			accel_iproute_del(ses, 0, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name);
 	}
 
 	if (rpd->acct_started || rpd->acct_req)

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -160,6 +160,15 @@ void __export ap_session_activate(struct ap_session *ses)
 	if (ap_shutdown)
 		return;
 
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks != NULL && ses->hooks->pppoe_create_session_interface) {
+		if (ses->hooks->pppoe_create_session_interface(ses)) {
+			ap_session_terminate(ses, TERM_NAS_ERROR, 0);
+			return;
+		}
+	}
+#endif /* HAVE_SESSION_HOOKS */
+
 	ap_session_ifup(ses);
 
 	if (ses->stop_time)
@@ -282,6 +291,11 @@ void __export ap_session_finished(struct ap_session *ses)
 		else
 			kill(getpid(), SIGTERM);
 	}
+
+#ifdef HAVE_SESSION_HOOKS
+	if (ses->hooks && ses->hooks->session_hook_deinit)
+		ses->hooks->session_hook_deinit(ses);
+#endif /* HAVE_SESSION_HOOKS */
 }
 
 void __export ap_session_terminate(struct ap_session *ses, int cause, int hard)

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -27,6 +27,10 @@
 #include "config.h"
 #include "memdebug.h"
 
+#ifdef HAVE_SESSION_HOOKS
+# include "ap_session_hooks.h"
+#endif /* HAVE_SESSION_HOOKS */
+
 #define SID_SOURCE_SEQ 0
 #define SID_SOURCE_URANDOM 1
 
@@ -76,6 +80,12 @@ void __export ap_session_init(struct ap_session *ses)
 	ses->ifindex = -1;
 	ses->unit_idx = -1;
 	ses->net = net;
+
+#ifdef HAVE_SESSION_HOOKS
+	ses->hooks = NULL;
+#endif /* HAVE_SESSION_HOOKS */
+
+	ses->vrf_name = NULL;
 }
 
 void __export ap_session_set_ifindex(struct ap_session *ses)

--- a/accel-pppd/triton/timer.c
+++ b/accel-pppd/triton/timer.c
@@ -201,6 +201,11 @@ void __export triton_timer_del(struct triton_timer_t *ud)
 {
 	struct _triton_timer_t *t = (struct _triton_timer_t *)ud->tpd;
 
+	if (ud == NULL || t == NULL) {
+		/* double time del? */
+		return;
+	}
+
 	spin_lock(&t->ctx->lock);
 	t->ud = NULL;
 	list_del(&t->entry);


### PR DESCRIPTION
The current patch provides only the interface for hooks.
Later updates and patches would provide partial implementation.
Updates to cmake/build system would be provided when all implementation would be accepted.

Basic interface that VPP plugin should implement.
Creating and destroing PPPoE session.
Implementing the substitute for the netlink routine. Installing/deleting the limiter.
Flags to manipulate usage of /dev/ppp interface and sockets for ND/DHCPv6 services.