### PR TITLE
ipoe: disable offer-timeout for UP IPoE

### DIFF
--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -978,10 +978,12 @@ static void __ipoe_session_start(struct ipoe_session *ses)
 		}
 	}
 
-	ses->timer.expire = ipoe_session_timeout;
-	ses->timer.period = 0;
-	ses->timer.expire_tv.tv_sec = conf_offer_timeout;
-	triton_timer_add(&ses->ctx, &ses->timer, 0);
+	if (!ses->UP) {
+		ses->timer.expire = ipoe_session_timeout;
+		ses->timer.period = 0;
+		ses->timer.expire_tv.tv_sec = conf_offer_timeout;
+		triton_timer_add(&ses->ctx, &ses->timer, 0);
+	}
 }
 
 static void make_ipv6_intfid(uint64_t *intfid, const uint8_t *hwaddr)

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -136,7 +136,7 @@ static void ap_session_timer(struct triton_timer_t *t)
 
 	if (ses->idle_timeout && ts.tv_sec - ses->idle_time >= ses->idle_timeout) {
 		log_ppp_msg("idle timeout\n");
-		ap_session_terminate(ses, TERM_SESSION_TIMEOUT, 0);
+		ap_session_terminate(ses, TERM_IDLE_TIMEOUT, 0);
 	} else if (ses->session_timeout) {
 		if (ts.tv_sec - ses->start_time >= ses->session_timeout) {
 			log_ppp_msg("session timeout\n");


### PR DESCRIPTION
sessions: Use idle-timeout value for Acct-Terminate-Cause when idle timeout fires