### PR TITLE
Fix vlan_mod kernel WARNING issue

### DIFF
--- a/.github/workflows/run-tests-32bit.yml
+++ b/.github/workflows/run-tests-32bit.yml
@@ -155,8 +155,17 @@ jobs:
       - name: Run tests (all)
         timeout-minutes: 5
         run: >
-          ssh -i ssh-key -p2222 root@localhost "cd accel-ppp/tests && 
+          ssh -i ssh-key -p2222 root@localhost "cd accel-ppp/tests &&
           python3 -m pytest -Wall --order-dependencies -v -m \"not chap_secrets\""
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: ssh -i ssh-key -p2222 -o ConnectTimeout=5 root@localhost "ps aux | grep accel- && dmesg"
+
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          ssh -i ssh-key -p2222 -o ConnectTimeout=5 root@localhost "dmesg" > /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi

--- a/.github/workflows/run-tests-asan-ubsan.yml
+++ b/.github/workflows/run-tests-asan-ubsan.yml
@@ -26,16 +26,16 @@ jobs:
     steps:
       - name: Install build tools (using apt)
         run: >
-          sudo apt update && 
+          sudo apt update &&
           NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true sudo -E apt -y install
           git build-essential cmake gcc linux-headers-`uname -r`
-          libpcre2-dev libssl-dev liblua5.1-0-dev kmod python3-pip 
+          libpcre2-dev libssl-dev liblua5.1-0-dev kmod python3-pip
           iproute2 ppp pppoe isc-dhcp-client
 
       - name: Install testing tools (using pip)
         run: >
-          sudo apt -y install python3-pytest python3-pytest-dependency python3-pytest-order || 
-          sudo pip3 install pytest pytest-dependency pytest-order || 
+          sudo apt -y install python3-pytest python3-pytest-dependency python3-pytest-order ||
+          sudo pip3 install pytest pytest-dependency pytest-order ||
           sudo pip3 install --break-system-packages pytest pytest-dependency pytest-order
 
       - name: Check out repository code
@@ -51,8 +51,8 @@ jobs:
         run: >
           CFLAGS="-fsanitize=${{ matrix.sanitizer }} -fno-sanitize-recover=all -fno-omit-frame-pointer -O2 -g"
           LDFLAGS="-fsanitize=${{ matrix.sanitizer }}"
-          cmake -DBUILD_IPOE_DRIVER=TRUE -DBUILD_VLAN_MON_DRIVER=TRUE -DCMAKE_INSTALL_PREFIX=/usr 
-          -DKDIR=/usr/src/linux-headers-`uname -r` 
+          cmake -DBUILD_IPOE_DRIVER=TRUE -DBUILD_VLAN_MON_DRIVER=TRUE -DCMAKE_INSTALL_PREFIX=/usr
+          -DKDIR=/usr/src/linux-headers-`uname -r`
           -DLUA=TRUE -DSHAPER=TRUE -DRADIUS=TRUE ..
 
       - name: make && make install
@@ -72,4 +72,13 @@ jobs:
         working-directory: ./tests
         env:
           ${{ matrix.env_name }}: ${{ matrix.env_value }}
-        run: sudo -E python3 -m pytest -Wall --order-dependencies -v 
+        run: sudo -E python3 -m pytest -Wall --order-dependencies -v
+
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          sudo dmesg | tee /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi

--- a/.github/workflows/run-tests-bigendian.yml
+++ b/.github/workflows/run-tests-bigendian.yml
@@ -162,8 +162,17 @@ jobs:
       - name: Run tests (all)
         timeout-minutes: 5
         run: >
-          ssh -i ssh-key -p2222 root@localhost "cd accel-ppp/tests && 
+          ssh -i ssh-key -p2222 root@localhost "cd accel-ppp/tests &&
           python3 -m pytest -Wall --order-dependencies -v -m \"not chap_secrets\""
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: ssh -i ssh-key -p2222 -o ConnectTimeout=5 root@localhost "ps aux | grep accel- && dmesg"
+
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          ssh -i ssh-key -p2222 -o ConnectTimeout=5 root@localhost "dmesg" > /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -170,13 +170,22 @@ jobs:
       - name: Run tests (all)
         timeout-minutes: 5
         run: >
-          ssh -i ssh-key -p2222 user@localhost "cd accel-ppp/tests && 
+          ssh -i ssh-key -p2222 user@localhost "cd accel-ppp/tests &&
           sudo python3 -m pytest -Wall --order-dependencies -v"
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: >
-          ssh -i ssh-key -p2222 user@localhost "ps aux | grep accel- && 
+          ssh -i ssh-key -p2222 user@localhost "ps aux | grep accel- &&
           sudo dmesg"
+
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          ssh -i ssh-key -p2222 user@localhost "sudo dmesg" > /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi
 
   Test-in-Alpine:
     #if: ${{ false }} # disable for now
@@ -299,13 +308,22 @@ jobs:
       - name: Run tests (all)
         timeout-minutes: 5
         run: >
-          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests && 
+          ssh -i ssh-key -p2222 alpine@localhost "cd accel-ppp/tests &&
           doas python3 -m pytest -Wall --order-dependencies -v -m \"not chap_secrets\""
       - name: Display processes and dmesg after tests
         if: ${{ always() }}
         run: >
-          ssh -i ssh-key -p2222 alpine@localhost "ps aux | grep accel- && 
+          ssh -i ssh-key -p2222 alpine@localhost "ps aux | grep accel- &&
           doas dmesg"
+
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          ssh -i ssh-key -p2222 alpine@localhost "doas dmesg" > /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi
 
 
   Test-in-GH:
@@ -363,6 +381,15 @@ jobs:
         working-directory: ./tests
         run: sudo python3 -m pytest -Wall --order-dependencies -v
 
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          sudo dmesg | tee /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi
+
   Test-in-GH-Coverage:
     #if: ${{ false }} # disable for now
     strategy:
@@ -418,6 +445,15 @@ jobs:
         timeout-minutes: 5
         working-directory: ./tests
         run: sudo python3 -m pytest -Wall --order-dependencies -v || exit 0
+
+      - name: Check dmesg for kernel issues
+        if: ${{ always() }}
+        run: |
+          sudo dmesg | tee /tmp/dmesg.log
+          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+            echo "::error::Kernel issues detected in dmesg"
+            exit 1
+          fi
 
       - name: Generate coverage reports (default(txt), csv, html)
         run: |

--- a/drivers/vlan_mon/vlan_mon.c
+++ b/drivers/vlan_mon/vlan_mon.c
@@ -753,6 +753,9 @@ static int __init vlan_mon_init(void)
 	}
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,0)
+	vlan_pt.af_packet_net = &init_net;
+#endif
 	dev_add_pack(&vlan_pt);
 
 	return 0;


### PR DESCRIPTION
Fixes https://github.com/accel-ppp/accel-ppp/issues/311

Modern kernels require af_packet_net (or dev) to be set on packet_type entries with type == ETH_P_ALL. Without it we get kernel WARNING, and registration will fail.