### PR TITLE
ci: Tightening warning condition in dmesg checks

### DIFF
--- a/.github/workflows/run-tests-32bit.yml
+++ b/.github/workflows/run-tests-32bit.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{ always() }}
         run: |
           ssh -i ssh-key -p2222 -o ConnectTimeout=5 root@localhost "dmesg" > /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi

--- a/.github/workflows/run-tests-asan-ubsan.yml
+++ b/.github/workflows/run-tests-asan-ubsan.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ always() }}
         run: |
           sudo dmesg | tee /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi

--- a/.github/workflows/run-tests-bigendian.yml
+++ b/.github/workflows/run-tests-bigendian.yml
@@ -172,7 +172,7 @@ jobs:
         if: ${{ always() }}
         run: |
           ssh -i ssh-key -p2222 -o ConnectTimeout=5 root@localhost "dmesg" > /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -182,7 +182,7 @@ jobs:
         if: ${{ always() }}
         run: |
           ssh -i ssh-key -p2222 user@localhost "sudo dmesg" > /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi
@@ -320,7 +320,7 @@ jobs:
         if: ${{ always() }}
         run: |
           ssh -i ssh-key -p2222 alpine@localhost "doas dmesg" > /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi
@@ -385,7 +385,7 @@ jobs:
         if: ${{ always() }}
         run: |
           sudo dmesg | tee /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi
@@ -450,7 +450,7 @@ jobs:
         if: ${{ always() }}
         run: |
           sudo dmesg | tee /tmp/dmesg.log
-          if grep -E 'WARNING:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
+          if grep -E 'WARNING: CPU:|BUG:|Oops:|kernel panic|general protection fault|KASAN|UBSAN:|soft lockup|hard LOCKUP|INFO: task .+ blocked|Bad page state|invalid opcode' /tmp/dmesg.log; then
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi


### PR DESCRIPTION
The boot-time RETBleed: WARNING: Spectre v2 mitigation... line matches the broad WARNING: regex.
The intent of that pattern was to catch kernel WARN_ON() splats, which always begin with WARNING: CPU:. We can tighten checks, to avoid false positive.

Recent false positive:

[  798.854655] NET: Registered PF_PPPOX protocol family
[  798.856587] gre: GRE over IPv4 demultiplexor driver
[  798.857644] PPTP driver version 0.8.5
[  802.391320] 8021q: 802.1Q VLAN Support v1.8
[    0.499048] RETBleed: WARNING: Spectre v2 mitigation leaves CPU vulnerable to RETBleed attacks, data leaks possible!
Error: Kernel issues detected in dmesg
Error: Process completed with exit code 1.
