### PR TITLE
log_file: don't register general target when log-file is unset

### DIFF
--- a/accel-pppd/logs/log_file.c
+++ b/accel-pppd/logs/log_file.c
@@ -385,7 +385,12 @@ static void general_reopen(void)
 {
 	const char *fname = conf_get_opt("log", "log-file");
 	int old_fd = -1;
- 	int fd = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
+	int fd;
+
+	if (!fname)
+		return;
+
+	fd = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		log_emerg("log_file: open '%s': %s\n", fname, strerror(errno));
 		return;
@@ -710,7 +715,8 @@ static void init(void)
 	if (opt && atoi(opt) > 0)
 		conf_copy = 1;
 
-	log_register_target(&general_target);
+	if (log_file)
+		log_register_target(&general_target);
 
 	if (conf_per_user_dir) {
 		log_register_target(&per_user_target);


### PR DESCRIPTION
The general log target was registered unconditionally in init(), even when no log-file= option was configured. The backing log_file pointer is only allocated when the option is present, so the first general-routed log message dereferenced NULL in queue_log() (spin_lock(&NULL->lock)), crashing the daemon. This made commenting out log-file= a foot-gun.

Guard the registration on log_file being allocated, mirroring how the fail/per-user/per-session targets are already conditional. Also bail out of general_reopen() early when log-file is unset, so a SIGHUP after a config reload that dropped log-file can't call open(NULL, ...).