### PR TITLE
ci: harden s390x qemu test against modloop/disk flakes

### DIFF
--- a/.github/workflows/run-tests-bigendian.yml
+++ b/.github/workflows/run-tests-bigendian.yml
@@ -47,7 +47,7 @@ jobs:
           screen -dmS httpserver python3 -m http.server 8000
       - name: Run target OS first time (for setup actions)
         run: >
-          sudo screen -dmS qemu
+          sudo screen -dmS qemu -L -Logfile qemu-console-setup.log
           qemu-system-s390x -M s390-ccw-virtio
           -m 4096 -smp 2 -nographic
           -net nic -net user,hostfwd=tcp::2222-:22
@@ -70,6 +70,20 @@ jobs:
           sleep 5;
           done;
           cat ~/.ssh/known_hosts
+      - name: Wait for disk to be available
+        # virtio_blk is not in the netboot initramfs; it comes from the modloop
+        # image the VM downloads at boot. If that download fails, sshd still
+        # comes up but /dev/vda never appears, so retry the modloop service
+        # until the disk is visible.
+        timeout-minutes: 10
+        run: >
+          while ! ssh -i ssh-key -p2222 root@localhost "test -e /sys/block/vda/device";
+          do
+          echo "Disk not visible, retrying modloop download";
+          ssh -i ssh-key -p2222 root@localhost
+          "rc-service modloop restart; rc-service hwdrivers restart; modprobe virtio_blk 2>/dev/null; ls /lib/modules" || true;
+          sleep 10;
+          done
       - name: Setup alpine to disk
         run: >
           ssh -i ssh-key -p2222 root@localhost "setup-alpine -c setup_alpine_conf &&
@@ -91,7 +105,7 @@ jobs:
           done;
       - name: Run target OS
         run: >
-          sudo screen -dmS qemu
+          sudo screen -dmS qemu -L -Logfile qemu-console.log
           qemu-system-s390x -M s390-ccw-virtio
           -m 4096 -smp 2 -nographic
           -net nic -net user,hostfwd=tcp::2222-:22
@@ -176,3 +190,10 @@ jobs:
             echo "::error::Kernel issues detected in dmesg"
             exit 1
           fi
+      - name: Display QEMU console logs
+        if: ${{ always() }}
+        run: |
+          for f in qemu-console-setup.log qemu-console.log; do
+            echo "===== $f ====="
+            sudo cat "$f" || true
+          done


### PR DESCRIPTION
## Problem

The big-endian (s390x Alpine in QEMU) workflow has two recurring failure modes:

1. **"Setup alpine to disk" fails** with `/dev/vda is not a block device suitable for partitioning` (e.g. run 26959281680). Root cause: the s390x netboot initramfs ships `virtio_net` but **not** `virtio_blk` — the block driver only becomes available after the modloop image is downloaded over the network by the `modloop` sysinit service. If that download fails, boot continues and sshd comes up normally, but `/dev/vda` never appears, so `setup-disk` dies at its `/sys/block/vda/device` check.

2. **"Wait for ssh connection" after the reboot from disk times out** (most failed runs: 27215304167, 26883289608, 26620915312, …). Currently undiagnosable because the QEMU console output is discarded by `screen -dmS`.

## Changes

- Add a **"Wait for disk to be available"** step before `setup-alpine`: polls for `/sys/block/vda/device` (the exact check setup-disk performs), restarting the `modloop` and `hwdrivers` services on each retry so a failed modloop download is re-attempted and `virtio_blk` gets coldplugged. 10-minute timeout with a clear error message.
- Capture the **QEMU console** for both VM launches (`screen -L -Logfile`) and dump the logs in a final `if: always()` step, so the next occurrence of failure mode 2 shows whether zipl/the kernel even starts booting from disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)