### PR TITLE
ipoe: fix two memory leaks (relay reply packet, username string)

### DIFF
--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -783,6 +783,10 @@ static void ipoe_session_start(struct ipoe_session *ses)
 		return;
 	}
 
+	/* take ownership now so the string is freed by ipoe_session_free()
+	 * even if the session terminates before auth_result() consumes it */
+	ses->username = username;
+
 	ses->ses.unit_idx = ses->serv->ifindex;
 
 	triton_event_fire(EV_CTRL_STARTING, &ses->ses);
@@ -794,7 +798,6 @@ static void ipoe_session_start(struct ipoe_session *ses)
 		return;
 
 	if (conf_noauth) {
-		ses->username = username;
 		r = PWDB_SUCCESS;
 	} else {
 #ifdef RADIUS
@@ -813,7 +816,6 @@ static void ipoe_session_start(struct ipoe_session *ses)
 		} else
 			pass = username;
 
-		ses->username = username;
 		r = pwdb_check(&ses->ses, (pwdb_callback)auth_result, ses, username, PPP_PAP, pass);
 
 		if (r == PWDB_WAIT)
@@ -1241,6 +1243,9 @@ static void ipoe_session_free(struct ipoe_session *ses)
 
 	if (ses->l4_redirect_ipset)
 		_free(ses->l4_redirect_ipset);
+
+	if (ses->username)
+		_free(ses->username);
 
 	triton_context_unregister(&ses->ctx);
 

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -2030,6 +2030,7 @@ static void ipoe_ses_recv_dhcpv4_relay(struct dhcpv4_packet *pack)
 
 	if (!ses->dhcpv4_request) {
 		ses->dhcpv4_relay_reply = NULL;
+		dhcpv4_packet_free(pack);
 		return;
 	}
 


### PR DESCRIPTION
Two small leak fixes in the IPoE module, extracted and rebased from the still-valid parts of #101 (credit to @louis-6wind for the original report).

**1. dhcpv4 relay reply packet leak.** `dhcpv4_relay_read()` refs the reply packet per listener context and hands it over via `triton_context_call()`. `ipoe_ses_recv_dhcpv4_relay()` consumes the ref by storing it in `ses->dhcpv4_relay_reply`, but the early-return branch taken when `ses->dhcpv4_request` is already gone dropped the ref without freeing. Leaks one packet per relay-reply/request-teardown race — recurring on busy relay-mode deployments.

**2. username string leak on early session teardown.** The ipoe-level `ses->username` always holds an allocated string, but `ipoe_session_free()` never released it; ownership only transfers if `auth_result()` runs (it hands the string to `ap_session_set_username()`). Sessions dying before that — termination while starting, `ipoe_create_interface()` failure (which also leaked the fresh local copy outright) — leaked the string. Fix: store the string in `ses->username` immediately after `ipoe_session_get_username()` and free it in `ipoe_session_free()`. No double free: `auth_result()` clears `ses->username` before transferring ownership.

The remaining hunks of #101 no longer apply: the `_strdup`/`_free` username handling was superseded by the `auth_result()` ownership-transfer rework, and the `triton.c` thread-struct free only matters at daemon shutdown.