### PR TITLE
sstp: reject packets shorter than header

### DIFF
--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2082,8 +2082,8 @@ static int sstp_handler(struct sstp_conn_t *conn, struct buffer_t *buf)
 		}
 
 		n = ntohs(hdr->length);
-		if (n > SSTP_MAX_PACKET_SIZE) {
-			log_ppp_error("recv [SSTP too long packet]\n");
+		if (n < sizeof(*hdr) || n > SSTP_MAX_PACKET_SIZE) {
+			log_ppp_error("recv [SSTP invalid packet length %d]\n", n);
 			return -1;
 		} else if (n > buf->len)
 			break;


### PR DESCRIPTION
A peer can send an SSTP packet with a zero encoded length and an unknown packet type. The receive dispatcher accepts the unknown type, after which buf_pull() consumes no data and the handler loops forever on the same packet, monopolizing a Triton worker.

Reject all packet lengths smaller than the SSTP header before dispatch so malformed packets close the connection without entering the non-progressing loop.