### PR TITLE
ppp: avoid unaligned MPPE option store

### DIFF
--- a/accel-pppd/ppp/ccp_mppe.c
+++ b/accel-pppd/ppp/ccp_mppe.c
@@ -102,11 +102,12 @@ static int setup_mppe_key(int fd, int transmit, uint8_t *key)
 {
 	struct ppp_option_data data;
 	uint8_t buf[6 + 16];
+	uint32_t bits = htonl(MPPE_S | MPPE_H);
 
 	memset(buf, 0, sizeof(buf));
 	buf[0] = CI_MPPE;
 	buf[1] = 6;
-	*(uint32_t*)(buf + 2) = htonl(MPPE_S | MPPE_H);
+	memcpy(buf + 2, &bits, sizeof(bits));
 	if (key)
 		memcpy(buf + 6, key, 16);
 

--- a/tests/accel-pppd/pppoe/test_pppoe_session_wo_auth.py
+++ b/tests/accel-pppd/pppoe/test_pppoe_session_wo_auth.py
@@ -17,6 +17,9 @@ def accel_pppd_config(veth_pair_netns):
     [core]
     log-error=/dev/stderr
 
+    [ppp]
+    mppe=prefer
+
     [log]
     log-debug=/dev/stdout
     log-file=/dev/stdout


### PR DESCRIPTION
Serialize the MPPE capability bits through an aligned temporary so the PPPIOCSCOMPRESS payload remains valid on strict-alignment targets and under UBSan. Exercise mppe=prefer in the existing PPPoE session test.